### PR TITLE
1.8.7 Support

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -30,11 +30,10 @@ module Sorcery
 
             # Mongoid support
             self.class_eval do
-              field sorcery_config.username_attribute_name, type: String
-              #field sorcery_config.password_attribute_name, type: String
-              field sorcery_config.email_attribute_name, type: String unless sorcery_config.username_attribute_name == sorcery_config.email_attribute_name
-              field sorcery_config.crypted_password_attribute_name, type: String
-              field sorcery_config.salt_attribute_name, type: String
+              field sorcery_config.username_attribute_name, :type => String
+              field sorcery_config.email_attribute_name, :type => String unless sorcery_config.username_attribute_name == sorcery_config.email_attribute_name
+              field sorcery_config.crypted_password_attribute_name, :type => String
+              field sorcery_config.salt_attribute_name, :type => String
             end if defined?(Mongoid) and self.ancestors.include?(Mongoid::Document)
 
             # add virtual password accessor and ORM callbacks


### PR DESCRIPTION
Use the 1.8.7 supported hash syntax. Otherwise, Sorcery doesn't work in 1.8.7. It's in your Mongoid support (field definitions)
