### PR TITLE
Ruby 1.9.2 / 1.8.7 Hash Syntax issue

### DIFF
--- a/spec/rails3_mongoid/app/models/authentication.rb
+++ b/spec/rails3_mongoid/app/models/authentication.rb
@@ -1,7 +1,7 @@
 class Authentication
   include Mongoid::Document
-  field :user_id, type: Integer
-  field :provider, type: String
-  field :uid, type: Integer
+  field :user_id, :type => Integer
+  field :provider, :type => String
+  field :uid, :type => Integer
   belongs_to :user
 end


### PR DESCRIPTION
Noticed most of these were fixed between v0.5.2 and v.5.21 but found a few left over.
