### PR TITLE
Validate confirmation of password during reset

### DIFF
--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -141,6 +141,24 @@ shared_examples_for "rails_3_reset_password_model" do
       @user.reset_password_token.should be_nil
     end
     
+    it "when change_password! is called, should validate confirmation if provided" do
+      create_new_user
+      @user.deliver_reset_password_instructions!
+      @user.reset_password_token.should_not be_nil
+      @user.change_password!("blabulsdf", "blabulsdf")
+      @user.save!
+      @user.reset_password_token.should be_nil
+    end
+    
+    it "when change_password! is called, should raise validation error if confirmation password does not match" do
+      create_new_user
+      @user.deliver_reset_password_instructions!
+      @user.reset_password_token.should_not be_nil
+      @user.change_password!("blabulsdf", 'lololol').should == false
+      @user.should have(1).error
+      @user.errors[:password].should == ["doesn't match confirmation"]
+    end
+    
     it "should not send an email if time between emails has not passed since last email" do
       create_new_user
       sorcery_model_property_set(:reset_password_time_between_emails, 10000)


### PR DESCRIPTION
Saw a todo in the wiki for this. 

Added ability to validate confirmation of password during reset if confirmation password provided. 

change_password! returns false if confirmation is provided and does not match the given password. It will also add a validation error to the user. 

Works with Mongoid and ActiveRecord.

Putting an error on the user let's the form handle the errors or the developer catch it (and write a flash[:alert] for example).

```
def update
  @user = User.load_from_reset_password_token(params[:token])
  not_authenticated if !@user

  # the next line clears the temporary token and updates the password
  if @user.change_password!(params[:user][:password], params[:user][:password_confirmation])
    redirect_to(root_path, :notice => 'Password was successfully updated.')
  else
    if @user.errors[:password]
      flash[:alert] = "Confirmation doesn't match your password"
    end
    render :action => "edit"
  end
end
```
