### PR TITLE
Make Twitter auth use the right authorize path

### DIFF
--- a/lib/sorcery/controller/submodules/external/providers/twitter.rb
+++ b/lib/sorcery/controller/submodules/external/providers/twitter.rb
@@ -40,8 +40,8 @@ module Sorcery
                 
                 include Protocols::Oauth1
 				
-				# Override included get_consumer method to provide authorize_path
-				def get_consumer
+				        # Override included get_consumer method to provide authorize_path
+				        def get_consumer
                   ::OAuth::Consumer.new(@key, @secret, :site => @site, :authorize_path => "/oauth/authenticate")
                 end
                 


### PR DESCRIPTION
In reference to issues #25 make Twitter auth use the right authorize path to enable quick sign in

https://dev.twitter.com/docs/auth/sign-in-with-twitter
