### PR TITLE
Making the gemspec valid again

### DIFF
--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -128,7 +128,6 @@ Gem::Specification.new do |s|
     "spec/rails3/public/500.html",
     "spec/rails3/public/favicon.ico",
     "spec/rails3/public/images/rails.png",
-    "spec/rails3/public/index.html",
     "spec/rails3/public/javascripts/application.js",
     "spec/rails3/public/javascripts/controls.js",
     "spec/rails3/public/javascripts/dragdrop.js",


### PR DESCRIPTION
Anyone with gem 'sorcery', :git => "git://github.com/NoamB/sorcery.git", :branch => "master" in their Gemfile will recieve an error right  now.
