### PR TITLE
Fix "undefined method forget_me!" for remember_me submodule

### DIFF
--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -22,7 +22,7 @@ module Sorcery
 
           # Clears the cookie and clears the token from the db.
           def forget_me!
-            current_user.forget_me!
+            @current_user.forget_me!
             cookies[:remember_me_token] = nil
           end
           


### PR DESCRIPTION
Even after [switching the order of `after_logout!` and `@current_user = nil`](https://github.com/NoamB/sorcery/issues/76), I was still getting this error when logging out. I needed to change `current_user` to `@current_user` for it to work.
