### PR TITLE
2 fixes for remember_me

### DIFF
--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -1,7 +1,7 @@
 module Sorcery
   module Controller
     module Submodules
-      # The Remember Me submodule takes care of setting the user's cookie so that he will 
+      # The Remember Me submodule takes care of setting the user's cookie so that he will
       # be automatically logged in to the site on every visit,
       # until the cookie expires.
       # See Sorcery::Model::Submodules::RememberMe for configuration options.
@@ -12,12 +12,12 @@ module Sorcery
           Config.after_login << :remember_me_if_asked_to
           Config.after_logout << :forget_me!
         end
-        
+
         module InstanceMethods
           # This method sets the cookie and calls the user to save the token and the expiration to db.
           def remember_me!
             current_user.remember_me!
-            set_remember_me_cookie!(current_user)      
+            set_remember_me_cookie!(current_user)
           end
 
           # Clears the cookie and clears the token from the db.
@@ -25,7 +25,7 @@ module Sorcery
             @current_user.forget_me!
             cookies.delete(:remember_me_token, :domain => Config.cookie_domain)
           end
-          
+
           # Override.
           # logins a user instance, and optionally remembers him.
           def auto_login(user, should_remember = false)
@@ -33,31 +33,32 @@ module Sorcery
             @current_user = user
             remember_me! if should_remember
           end
-          
+
           protected
-          
+
           # calls remember_me! if a third credential was passed to the login method.
           # Runs as a hook after login.
           def remember_me_if_asked_to(user, credentials)
             remember_me! if ( credentials.size == 3 && credentials[2] && credentials[2] != "0" )
           end
-          
-          # Checks the cookie for a remember me token, tried to find a user with that token 
+
+          # Checks the cookie for a remember me token, tried to find a user with that token
           # and logs the user in if found.
           # Runs as a login source. See 'current_user' method for how it is used.
           def login_from_cookie
             user = cookies.signed[:remember_me_token] && user_class.find_by_remember_me_token(cookies.signed[:remember_me_token])
             if user && user.remember_me_token?
               set_remember_me_cookie!(user)
+              session[:user_id] = user.id
               @current_user = user
             else
               @current_user = false
             end
           end
-          
+
           def set_remember_me_cookie!(user)
-            cookies.signed[:remember_me_token] = { 
-              :value => user.send(user.sorcery_config.remember_me_token_attribute_name), 
+            cookies.signed[:remember_me_token] = {
+              :value => user.send(user.sorcery_config.remember_me_token_attribute_name),
               :expires => user.send(user.sorcery_config.remember_me_token_expires_at_attribute_name),
               :httponly => true,
               :domain => Config.cookie_domain


### PR DESCRIPTION
First the deletion of the cookie when logging out was incorrect. "Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie" (http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html). So I fixed that.

I also fixed setting the user_id session on login_from_coockie. Otherwise no session was set on cookie login.

And sorry - I am going to write the specs very soon. I have been so busy lately. :-(
