### PR TITLE
Saving the user record should not trigger validations

### DIFF
--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -52,14 +52,14 @@ module Sorcery
           # This runs as a hook just after a successful login.
           def register_login_time_to_db(user, credentials)
             return unless Config.register_login_time
-            user.update_attributes!(user.sorcery_config.last_login_at_attribute_name => Time.now.utc)
+            user.update_attribute(user.sorcery_config.last_login_at_attribute_name, Time.now.utc)
           end
           
           # registers last logout time on every logout.
           # This runs as a hook just before a logout.
           def register_logout_time_to_db(user)
             return unless Config.register_logout_time
-            user.update_attributes!(user.sorcery_config.last_logout_at_attribute_name => Time.now.utc)
+            user.update_attribute(user.sorcery_config.last_logout_at_attribute_name, Time.now.utc)
           end
           
           # Updates last activity time on every request.
@@ -67,7 +67,7 @@ module Sorcery
           def register_last_activity_time_to_db
             return unless Config.register_last_activity_time
             return unless logged_in?
-            current_user.update_attributes!(current_user.sorcery_config.last_activity_at_attribute_name => Time.now.utc)
+            current_user.update_attribute(current_user.sorcery_config.last_activity_at_attribute_name, Time.now.utc)
           end
         end
       end

--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -30,7 +30,7 @@ module Sorcery
           # Runs as a hook after a successful login.
           def reset_failed_logins_count!(user, credentials)
             user.send(:"#{user_class.sorcery_config.failed_logins_count_attribute_name}=", 0)
-            user.save!
+            user.save!(:validate => false)
           end
         end
       end

--- a/lib/sorcery/model/submodules/brute_force_protection.rb
+++ b/lib/sorcery/model/submodules/brute_force_protection.rb
@@ -54,7 +54,7 @@ module Sorcery
             config = sorcery_config
             return if !unlocked?
             self.increment(config.failed_logins_count_attribute_name)
-            save!
+            save!(:validate => false)
             self.lock! if self.send(config.failed_logins_count_attribute_name) >= config.consecutive_login_retries_amount_limit
           end
           
@@ -63,14 +63,14 @@ module Sorcery
           def lock!
             config = sorcery_config
             self.send(:"#{config.lock_expires_at_attribute_name}=", Time.now.utc + config.login_lock_time_period)
-            self.save!
+            self.save!(validate: false)
           end
 
           def unlock!
             config = sorcery_config
             self.send(:"#{config.lock_expires_at_attribute_name}=", nil)
             self.send(:"#{config.failed_logins_count_attribute_name}=", 0)
-            self.save!
+            self.save!(validate: false)
           end
           
           def unlocked?


### PR DESCRIPTION
Newer versions of sorcery validate the user model. I believe in this pull request I have removed all calls that would trigger validation.
