### PR TITLE
Setting join token and stretches value for SHA1 encryption method

### DIFF
--- a/spec/sorcery_crypto_providers_spec.rb
+++ b/spec/sorcery_crypto_providers_spec.rb
@@ -54,7 +54,11 @@ describe "Crypto Providers wrappers" do
     it "matches? returns false when no match" do
       Sorcery::CryptoProviders::SHA1.matches?(@digest, 'Some Dude').should be_false
     end
-    
+
+    it "matches password encrypted using salt and join token from upstream" do
+      Sorcery::CryptoProviders::SHA1.join_token = "test"
+      Sorcery::CryptoProviders::SHA1.encrypt(['password', 'gq18WBnJYNh2arkC1kgH']).should == '894b5bf1643b8d0e1b2eaddb22426be7036dab70'
+    end
   end
 
   describe Sorcery::CryptoProviders::SHA256 do


### PR DESCRIPTION
Ref issue #67

When using the SHA1 encryption method creating users and authenticating in one server run works. But restarting the server (or console) makes authentication fail. Problem is that the credential check fails, because the join token and stretches value aren't set on the encryption provider. This is done in this commit. 

Added a test to the SHA1 spec section as well, that tests a "real" user signup using the salt and a join token set.
