### PR TITLE
Converted DateTime fields into Time

### DIFF
--- a/lib/sorcery/model/submodules/activity_logging.rb
+++ b/lib/sorcery/model/submodules/activity_logging.rb
@@ -39,9 +39,9 @@ module Sorcery
           protected
 
           def define_activity_logging_mongoid_fields
-            field sorcery_config.last_login_at_attribute_name,    :type => DateTime
-            field sorcery_config.last_logout_at_attribute_name,   :type => DateTime
-            field sorcery_config.last_activity_at_attribute_name, :type => DateTime
+            field sorcery_config.last_login_at_attribute_name,    :type => Time
+            field sorcery_config.last_logout_at_attribute_name,   :type => Time
+            field sorcery_config.last_activity_at_attribute_name, :type => Time
           end
         end
       end

--- a/lib/sorcery/model/submodules/brute_force_protection.rb
+++ b/lib/sorcery/model/submodules/brute_force_protection.rb
@@ -38,12 +38,12 @@ module Sorcery
 
           def define_brute_force_protection_mongoid_fields
             field sorcery_config.failed_logins_count_attribute_name,  :type => Integer
-            field sorcery_config.lock_expires_at_attribute_name,      :type => DateTime
+            field sorcery_config.lock_expires_at_attribute_name,      :type => Time
           end
 
           def define_brute_force_protection_mongo_mapper_fields
             key sorcery_config.failed_logins_count_attribute_name, Integer
-            key sorcery_config.lock_expires_at_attribute_name, DateTime
+            key sorcery_config.lock_expires_at_attribute_name, Time
           end
         end
         

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -72,13 +72,12 @@ module Sorcery
 
           def define_reset_password_mongoid_fields
             field sorcery_config.reset_password_token_attribute_name,             :type => String
-            field sorcery_config.reset_password_token_expires_at_attribute_name,  :type => DateTime
-            field sorcery_config.reset_password_email_sent_at_attribute_name,     :type => DateTime
+            field sorcery_config.reset_password_token_expires_at_attribute_name,  :type => Time
+            field sorcery_config.reset_password_email_sent_at_attribute_name,     :type => Time
           end
           
           def define_reset_password_mongo_mapper_fields
             key sorcery_config.reset_password_token_attribute_name, String
-            # no DateTime in MM
             key sorcery_config.reset_password_token_expires_at_attribute_name, Time
             key sorcery_config.reset_password_email_sent_at_attribute_name, Time
           end

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -84,7 +84,7 @@ module Sorcery
             self.class_eval do
               field sorcery_config.activation_state_attribute_name,            :type => String
               field sorcery_config.activation_token_attribute_name,            :type => String
-              field sorcery_config.activation_token_expires_at_attribute_name, :type => DateTime
+              field sorcery_config.activation_token_expires_at_attribute_name, :type => Time
             end
           end
 
@@ -92,7 +92,6 @@ module Sorcery
             self.class_eval do
               key sorcery_config.activation_state_attribute_name, String
               key sorcery_config.activation_token_attribute_name, String
-              # no DateTime in MM
               key sorcery_config.activation_token_expires_at_attribute_name, Time
             end
           end


### PR DESCRIPTION
Time has better timezone support. With Mongoid, a DateTime will always be returned from the database in UTC, whereas a Time will return in local timezone if Time.zone is set.
