### PR TITLE
Fixes #105 - Hammering protection checker

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -88,7 +88,7 @@ module Sorcery
           def deliver_reset_password_instructions!
             config = sorcery_config
             # hammering protection
-            return if config.reset_password_time_between_emails && self.send(config.reset_password_email_sent_at_attribute_name) && self.send(config.reset_password_email_sent_at_attribute_name) > config.reset_password_time_between_emails.ago.utc
+            return false if config.reset_password_time_between_emails && self.send(config.reset_password_email_sent_at_attribute_name) && self.send(config.reset_password_email_sent_at_attribute_name) > config.reset_password_time_between_emails.ago.utc
             self.send(:"#{config.reset_password_token_attribute_name}=", TemporaryToken.generate_random_token)
             self.send(:"#{config.reset_password_token_expires_at_attribute_name}=", Time.now.in_time_zone + config.reset_password_expiration_period) if config.reset_password_expiration_period
             self.send(:"#{config.reset_password_email_sent_at_attribute_name}=", Time.now.in_time_zone)

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -150,6 +150,14 @@ shared_examples_for "rails_3_reset_password_model" do
       @user.deliver_reset_password_instructions!
       ActionMailer::Base.deliveries.size.should == old_size + 1
     end
+
+    it "should return false if time between emails has not passed since last email" do
+      create_new_user
+      sorcery_model_property_set(:reset_password_time_between_emails, 10000)
+      old_size = ActionMailer::Base.deliveries.size
+      @user.deliver_reset_password_instructions!
+      @user.deliver_reset_password_instructions!.should == false
+    end
     
     it "should send an email if time between emails has passed since last email" do
       create_new_user


### PR DESCRIPTION
`deliver_reset_password_instructions!` now returns false if hammering protection is triggered as requested in #105. I'm not sure that this is totally necessary because the method already returns nil if hammering protection is triggered, but feel free to merge it if you want, and close the issue either way.
