### PR TITLE
Add check to see if we're using ActiveRecord

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -40,6 +40,7 @@ module Sorcery
       # Copy the migrations files to db/migrate folder
       def copy_migration_files
         # Copy core migration file in all cases except when you pass --migrations.
+        return unless defined?(Sorcery::Generators::InstallGenerator::ActiveRecord)
         migration_template "migration/core.rb", "db/migrate/sorcery_core.rb" unless options[:migrations]
 
         if submodules


### PR DESCRIPTION
So we don't create AR-specific migrations for non-AR ORMs. Should fix #128
