### PR TITLE
A simple change that clears out the session[:return_to_url] after a redi...

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -71,6 +71,7 @@ module Sorcery
       # and we want to return him back to the page he originally wanted.
       def redirect_back_or_to(url, flash_hash = {})
         redirect_to(session[:return_to_url] || url, :flash => flash_hash)
+        session[:return_to_url] = nil
       end
 
       # The default action for denying non-authenticated users.


### PR DESCRIPTION
...rect_back_or_to.  That way you can use the redirect_back_or_to method later in the session for a different page without being always sent back to the original page they were trying to reach before authentication.

For example, in my own app using sorcery, I have a model "Item" that has two different workflows in terms of editing.  You can get to the edit view from page A or page B.  The default workflow being A.  In my Page B controller I set the session[:return_to_url]. Then in my Item "update" controller I would like to use "redirect_back_or_to page_A_path" so that the user would be directed back to Page B if they came from there or Page A otherwise.  

This works great if the person is coming from Page B.  However, if they are coming from Page A after having earlier in their session attempted to access a secured page without being logged in, they are instead redirected back to whatever page they intially tried to get to before they logged in.  The session remembers it for perpuity.  

By clearing the session variable out, it allows the redirect_back_or_to method to be used for friendly forwarding throughout the site...not just in when a user is logging in.

I hope I am making sense.
