### PR TITLE
current_users + Mongoid

### DIFF
--- a/lib/sorcery/model/adapters/mongoid.rb
+++ b/lib/sorcery/model/adapters/mongoid.rb
@@ -72,7 +72,7 @@ module Sorcery
           def get_current_users
             config = sorcery_config
             where(config.last_activity_at_attribute_name.ne => nil) \
-            .any_of({config.last_logout_at_attribute_name => nil},{config.last_activity_at_attribute_name.gt => config.last_logout_at_attribute_name}) \
+            .where("this.#{config.last_logout_at_attribute_name} == null || this.#{config.last_activity_at_attribute_name} > this.#{config.last_logout_at_attribute_name}") \
             .and(config.last_activity_at_attribute_name.gt => config.activity_timeout.seconds.ago.utc.to_s(:db)).order_by([:_id,:asc])
           end
         end


### PR DESCRIPTION
Hi,

I've been using sorcery for a while and it's been working great. Just a couple of hours ago I've discovered that there is a function "current_users" and wanted to try it out. Unfortunately, I couldn't get it to work for me. Here's what I got:

> undefined method `to_i' for :last_logout_at

It seems that the query inside <tt>current_users</tt> method for Mongoid adapter isn't valid, so I tried to fix it.  With this fix it does work for me, not sure about the performance for that though (running javascript to test each record).
