### PR TITLE
Oauth2 fix

### DIFF
--- a/lib/sorcery/controller/submodules/external/protocols/oauth2.rb
+++ b/lib/sorcery/controller/submodules/external/protocols/oauth2.rb
@@ -20,9 +20,9 @@ module Sorcery
 
             def get_access_token(args, options = {})
               client = build_client(options)
-              client.auth_code.get_access_token(
+              client.auth_code.get_token(
                 args[:code],
-                :redirect_uri => @callback_url
+                { :redirect_uri => @callback_url, :parse => options.delete(:parse) }, options
               )
             end
 

--- a/lib/sorcery/controller/submodules/external/providers/facebook.rb
+++ b/lib/sorcery/controller/submodules/external/providers/facebook.rb
@@ -46,12 +46,16 @@ module Sorcery
                   @scope          = "email,offline_access"
                   @user_info_mapping = {}
                   @display        = "page"
+                  @token_url      = "oauth/access_token"
+                  @mode           = :query
+                  @parse          = :query
+                  @param_name     = "access_token"
                 end
                 
                 def get_user_hash
                   user_hash = {}
                   response = @access_token.get(@user_info_path)
-                  user_hash[:user_info] = JSON.parse(response)
+                  user_hash[:user_info] = JSON.parse(response.body)
                   user_hash[:uid] = user_hash[:user_info]['id']
                   user_hash
                 end
@@ -69,8 +73,9 @@ module Sorcery
                 # tries to login the user from access token
                 def process_callback(params,session)
                   args = {}
+                  options = { :token_url => @token_url, :mode => @mode, :param_name => @param_name, :parse => @parse }
                   args.merge!({:code => params[:code]}) if params[:code]
-                  @access_token = self.get_access_token(args)
+                  @access_token = self.get_access_token(args, options)
                 end
                 
               end

--- a/lib/sorcery/controller/submodules/external/providers/github.rb
+++ b/lib/sorcery/controller/submodules/external/providers/github.rb
@@ -51,7 +51,7 @@ module Sorcery
                 def get_user_hash
                   user_hash = {}
                   response = @access_token.get(@user_info_path)
-                  user_hash[:user_info] = JSON.parse(response)
+                  user_hash[:user_info] = JSON.parse(response.body)
                   user_hash[:uid] = user_hash[:user_info]['id']
                   user_hash
                 end

--- a/lib/sorcery/controller/submodules/external/providers/google.rb
+++ b/lib/sorcery/controller/submodules/external/providers/google.rb
@@ -44,7 +44,7 @@ module Sorcery
                 def init
                   @site              = "https://accounts.google.com"
                   @auth_url          = "/o/oauth2/auth"
-                  @token_path        = "/o/oauth2/token"
+                  @token_url         = "/o/oauth2/token"
                   @user_info_url     = "https://www.googleapis.com/oauth2/v1/userinfo"
                   @scope             = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
                   @user_info_mapping = {}
@@ -53,7 +53,7 @@ module Sorcery
                 def get_user_hash
                   user_hash = {}
                   response = @access_token.get(@user_info_url)
-                  user_hash[:user_info] = JSON.parse(response)
+                  user_hash[:user_info] = JSON.parse(response.body)
                   user_hash[:uid] = user_hash[:user_info]['id']
                   user_hash
                 end
@@ -73,8 +73,8 @@ module Sorcery
                   args = {}
                   args.merge!({:code => params[:code]}) if params[:code]
                   options = {
-                    :access_token_path => @token_path,
-                    :access_token_method => :post
+                    :token_url => @token_url,
+                    :token_method => :post
                   }
                   @access_token = self.get_access_token(args, options)
                 end

--- a/lib/sorcery/controller/submodules/external/providers/liveid.rb
+++ b/lib/sorcery/controller/submodules/external/providers/liveid.rb
@@ -54,7 +54,7 @@ module Sorcery
                   user_hash = {}
                   @access_token.token_param = "access_token"
                   response = @access_token.get(@user_info_url)
-                  user_hash[:user_info] = JSON.parse(response)
+                  user_hash[:user_info] = JSON.parse(response.body)
                   user_hash[:uid] = user_hash[:user_info]['id']
                   user_hash
                 end

--- a/spec/rails3/spec/controller_oauth2_spec.rb
+++ b/spec/rails3/spec/controller_oauth2_spec.rb
@@ -5,7 +5,8 @@ def stub_all_oauth2_requests!
   auth_code       = OAuth2::Strategy::AuthCode.any_instance
   access_token    = mock(OAuth2::AccessToken)
   access_token.stub(:token_param=)
-  access_token.stub(:get).and_return({
+  response        = mock(OAuth2::Response)
+  response.stub(:body).and_return({
     "id"=>"123",
     "name"=>"Noam Ben Ari",
     "first_name"=>"Noam",
@@ -21,7 +22,8 @@ def stub_all_oauth2_requests!
     "languages"=>[{"id"=>"108405449189952", "name"=>"Hebrew"}, {"id"=>"106059522759137", "name"=>"English"}, {"id"=>"112624162082677", "name"=>"Russian"}],
     "verified"=>true,
     "updated_time"=>"2011-02-16T20:59:38+0000"}.to_json)
-  auth_code.stub(:get_access_token).and_return(access_token)
+  access_token.stub(:get).and_return(response)
+  auth_code.stub(:get_token).and_return(access_token)
 end
 
 describe ApplicationController do


### PR DESCRIPTION
Dear all,

we are working on a web app and we decided to use sorcery 0.7.6 for user management and external login. Unfortunately, oauth2 has changed and something in sorcery was broken, so authentication in facebook didn't work anymore.

You can check the following issue: https://github.com/NoamB/sorcery/issues/184

We identified the problem and fix it and tested on facebook, twitter and google+

Best Regards

Geremia
