### PR TITLE
current_users and Mongoid - additional fix

### DIFF
--- a/lib/sorcery/model/adapters/mongoid.rb
+++ b/lib/sorcery/model/adapters/mongoid.rb
@@ -72,8 +72,8 @@ module Sorcery
           def get_current_users
             config = sorcery_config
             where(config.last_activity_at_attribute_name.ne => nil) \
-            .where("this.#{config.last_logout_at_attribute_name} == null || this.#{config.last_activity_at_attribute_name} > this.#{config.last_logout_at_attribute_name}") \
-            .and(config.last_activity_at_attribute_name.gt => config.activity_timeout.seconds.ago.utc.to_s(:db)).order_by([:_id,:asc])
+            .and("this.#{config.last_logout_at_attribute_name} == null || this.#{config.last_activity_at_attribute_name} > this.#{config.last_logout_at_attribute_name}") \
+            .and(config.last_activity_at_attribute_name.gt => config.activity_timeout.seconds.ago.utc).order_by([:_id,:asc])
           end
         end
       end


### PR DESCRIPTION
Hi,

I've removed conversion to String for the activity timeout, it seems that this way it does finally work for Mongoid.

Thanks.
