### PR TITLE
Change model_class_name behaviour

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -35,7 +35,7 @@ module Sorcery
         # Generate the model and add 'authenticates_with_sorcery!' unless you passed --migrations
         unless options[:migrations]
           generate "model #{model_class_name} --skip-migration"
-          insert_into_file "app/models/#{model_class_name.downcase}.rb", "  authenticates_with_sorcery!\n", :after => "class #{model_class_name} < ActiveRecord::Base\n"
+          insert_into_file "app/models/#{model_class_name.underscore}.rb", "  authenticates_with_sorcery!\n", :after => "class #{model_class_name} < ActiveRecord::Base\n"
         end
       end
 
@@ -68,9 +68,9 @@ module Sorcery
       
       private
 
-      # Either return the model passed in a capitalized form or return the default "User".
+      # Either return the model passed in a classified form or return the default "User".
       def model_class_name
-        options[:model] ? options[:model].capitalize : "User"
+        options[:model] ? options[:model].classify : "User"
       end
     end
   end


### PR DESCRIPTION
- Use classify instead of capitalize to make the behaviour of the generator
  more similar to Rails model generator.
- Use underscore instead of downcase for consistency with the previous change.

I think it's a fair change. This morning I run: 

`rails g sorcery:install --model AdminOrganization` 

And the output really surprised me.

Thank you for working on this great engine! I'm actually using it on all my brand-new projects.
