### PR TITLE
Login fails after call to current_user

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -29,6 +29,7 @@ module Sorcery
       # Takes credentials and returns a user on successful authentication.
       # Runs hooks after login or failed login.
       def login(*credentials)
+        @current_user = nil
         user = user_class.authenticate(*credentials)
         if user
           return_to_url = session[:return_to_url]


### PR DESCRIPTION
current_user returns false after login if it was called prior to login
during a given request (e.g. in a before_filter). Setting @current_user
to nil at start of login fixes this problem.

Sample:

```
application_controller:

class ApplicationController < ActionController::Base
  before_filter :do_something_with_current_user

  def do_something_with_current_user
    logged_in? # calls current_user
  end
end

session_controller:

class SessionController < ApplicationController
  def create
    raise Exception.new('login failed') unless login(params[:email], params[:password], params[:remember_me])
  end
end

session_controller_test:

class SessionControllerTest < ActionController::TestCase
  include Sorcery::TestCase::Rails

  test "login" do
    user = User.create!(email: 'user@sample.com', password: 'password')
    post :create, email: user.email, password: user.password, remember_me: false
    assert_response :success
  end
end
```
