### PR TITLE
Added validations for external users & multiple providers by account

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -57,6 +57,41 @@ module Sorcery
             @provider = Config.send(provider)
             @provider.access_token
           end
+
+          # If user is logged, he can add all available providers into his account
+          def add_provider_to_user(provider)
+            provider_name = provider.to_sym
+            provider = Config.send(provider_name)
+            user_hash = provider.get_user_hash
+            config = user_class.sorcery_config
+
+            user = current_user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => user_hash[:uid], config.provider_attribute_name => provider)
+            user.save(:validate => false)
+
+            return user
+          end
+
+          # Initialize new user from provider informations.
+          # If a provider doesn't give required informations or username/email is already taken,
+          # we store provider/user infos into a session and can be rendered into registration form
+          def create_and_validate_from(provider)
+            provider = provider.to_sym
+            @provider = Config.send(provider)
+            @user_hash = @provider.get_user_hash
+            config = user_class.sorcery_config
+
+            attrs = user_attrs(@provider.user_info_mapping, @user_hash)
+
+            user = user_class.new(attrs)
+            user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider)
+
+            session[:incomplete_user] = {
+              :provider => {config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider},
+              :user_hash => attrs
+            } unless user.save
+
+            return user
+          end
           
           # this method automatically creates a new user from the data in the external user hash.
           # The mappings from user hash fields to user db fields are set at controller config.
@@ -75,15 +110,9 @@ module Sorcery
             @provider = Config.send(provider)
             @user_hash = @provider.get_user_hash
             config = user_class.sorcery_config
-            attrs = {}
-            @provider.user_info_mapping.each do |k,v|
-              if (varr = v.split("/")).size > 1
-                attribute_value = varr.inject(@user_hash[:user_info]) {|hsh,v| hsh[v] } rescue nil
-                attribute_value.nil? ? attrs : attrs.merge!(k => attribute_value)
-              else
-                attrs.merge!(k => @user_hash[:user_info][v])
-              end
-            end
+
+            attrs = user_attrs(@provider.user_info_mapping, @user_hash)
+
             user_class.transaction do
               @user = user_class.new()
               attrs.each do |k,v|
@@ -94,6 +123,20 @@ module Sorcery
             end
             @user
           end
+
+          def user_attrs(user_info_mapping, user_hash)
+            attrs = {}
+            user_info_mapping.each do |k,v|
+              if (varr = v.split("/")).size > 1
+                attribute_value = varr.inject(user_hash[:user_info]) {|hash, value| hash[value]} rescue nil
+                attribute_value.nil? ? attrs : attrs.merge!(k => attribute_value)
+              else
+                attrs.merge!(k => user_hash[:user_info][v])
+              end
+            end
+            return attrs
+          end
+
         end
       end
     end


### PR DESCRIPTION
Because some providers doesn't give some informations, and in certains cases, user model have other required fields that need to be rendered in the registration form.

Here i use build association for authentications model. If a validation fail, provider information is stored in a session (uid etc...) then in the controller, we can render registration form.

And in this way, a user can login with credentials / externals providers & send an activation email

oauth_controller:

``` ruby
  def callback
    provider = params[:provider]
    if @user = login_from(provider)
      redirect_to profile_index_path, :notice => "Vous êtes désormais connecté ! (via #{provider.titleize})"
    else
      if logged_in?
        @user = add_provider_to_user(provider)
        if @user
          redirect_to root_path, :notice => "#{provider.titleize} ajouté à votre compte"
        else 
          redirect_to root_path, :notice => "Impossible d'ajouter #{provider.titleize} :("
        end
      else
        @user = create_and_validate_from(provider)
        unless @user.errors.size > 0
          @user = login_from(provider)
          redirect_to profile_index_path, :notice => "Bienvenue !"
        else
          render "users/registrations/new"
        end
      end
    end
  end
```

registrations_controller:

``` ruby

  def new
    @user = User.new((session[:incomplete_user][:user_hash] if session[:incomplete_user]))
  end

  def create
    @user = User.new user_params
    @user.authentications.build(session[:incomplete_user][:provider]) if session[:incomplete_user]

    if @user.save
      session[:incomplete_user] = nil
      redirect_to root_url, :notice => "Inscription réussie. Vous allez recevoir un email afin de valider votre compte"
    else
      render :new
    end
  end
```
