### PR TITLE
Fixing validate_mailer_defined bug (issue #267)

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -74,7 +74,7 @@ module Sorcery
           # when reset_password_mailer_disabled is false
           def validate_mailer_defined
             msg = "To use reset_password submodule, you must define a mailer (config.reset_password_mailer = YourMailerClass)."
-            raise ArgumentError, msg if @sorcery_config.reset_password_mailer == nil and @sorcery_config.reset_password_mailer_disabled == false
+            raise ArgumentError, msg if @sorcery_config.reset_password_mailer.try(:class).nil? and @sorcery_config.reset_password_mailer_disabled == false
           end
 
           def define_reset_password_mongoid_fields

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -85,7 +85,7 @@ module Sorcery
           # when activation_mailer_disabled is false
           def validate_mailer_defined
             msg = "To use user_activation submodule, you must define a mailer (config.user_activation_mailer = YourMailerClass)."
-            raise ArgumentError, msg if @sorcery_config.user_activation_mailer == nil and @sorcery_config.activation_mailer_disabled == false
+            raise ArgumentError, msg if @sorcery_config.user_activation_mailer.try(:class).nil? and @sorcery_config.activation_mailer_disabled == false
           end
 
           def define_user_activation_mongoid_fields


### PR DESCRIPTION
This is a small bug fix for two validate_mailer_defined methods.

When checking the config values of `user_activation_mailer` and `reset_password_mailer` the if statement does not always return what we expect. This `@sorcery_config.user_activation_mailer == nil` works in 90% but if you set the mailer like this `MyMailer.delay` where the delay method returns the class (what we have to when using delayed_job) you will get true instead of false.

As you can see from the commit i changed

``` ruby
@sorcery_config.user_activation_mailer == nil
@sorcery_config.reset_password_mailer == nil
```

to

``` ruby
@sorcery_config.user_activation_mailer.try(:class).nil?
@sorcery_config.reset_password_mailer.try(:class).nil?
```
