### PR TITLE
Adding the delayed_job integration instructions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -118,6 +118,26 @@ add them to the initializer file.
 Inside the initializer, the comments will tell you what each setting does.
 
 
+== DelayedJob Integration
+
+By default emails are sent synchronously. You can send them asynchronously by using the 
+[delayed_job gem](https://github.com/collectiveidea/delayed_job).
+
+After implementing the `delayed_job` into your project add the code below at the end of 
+the `config/initializers/sorcery.rb` file. After that all emails will be sent asynchronously.
+
+  module Sorcery
+    module Model
+      module InstanceMethods
+        def generic_send_email(method, mailer)
+          config = sorcery_config
+          mail = config.send(mailer).delay.send(config.send(method), self)
+        end
+      end
+    end
+  end
+
+
 == Full Features List by module:
 
 


### PR DESCRIPTION
This commit adds instructions how to integrate delayed_job to send emails asynchronously. I was thinking about some code upgrade for that but the simple description is a better way for now i guess (a quick `fix` and everyone will love it :) ).
