### PR TITLE
bundler won't bundle if parent bundler exists already, so empty it.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,10 +46,7 @@ task :all_sorcery_specs do
   # we need to be empty, otherwise bundler will use parent bundler.
   env = {
     'BUNDLE_GEMFILE' => nil,
-    'GEM_PATH' => nil,
-    'GEM_HOME' => nil,
-    'BUNDLE_BIN_PATH' => nil,
-    'RUBYOPT' => nil
+    'GEM_HOME'       => nil
   }
   Dir['spec/**/Rakefile'].each do |rakefile|
     directory_name = File.dirname(rakefile)


### PR DESCRIPTION
`task :all_sorcery_specs` will fail because of the bundler.
bundler won't bundle if parent bundler's env already exists.
now at least it works with each spec bundler's world:

```
$ bundle exec rake
```
