### PR TITLE
Fix bcrypt-ruby dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source :rubygems
 #   gem "activesupport", ">= 2.3.5"
 gem 'oauth', "~> 0.4.4"
 gem 'oauth2', "~> 0.5.1"
+gem 'bcrypt-ruby', "~> 3.0.0"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
@@ -20,7 +21,6 @@ group :development do
   gem 'simplecov', '>= 0.3.8', :require => false # Will install simplecov-html as a dependency
   gem 'timecop'
 	gem 'capybara'
-	gem 'bcrypt-ruby', "~> 3.0.0"
 	gem 'mongo_mapper'
 	gem 'mongoid', "~> 2.4.4"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,10 @@ GEM
     mime-types (1.18)
     mongo (1.6.1)
       bson (~> 1.6.1)
+    mongo_mapper (0.11.1)
+      activemodel (~> 3.0)
+      activesupport (~> 3.0)
+      plucky (~> 0.4.0)
     mongoid (2.4.7)
       activemodel (~> 3.1)
       mongo (~> 1.3)
@@ -81,6 +85,8 @@ GEM
     oauth2 (0.5.2)
       faraday (~> 0.7)
       multi_json (~> 1.0)
+    plucky (0.4.4)
+      mongo (~> 1.5)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.2)
@@ -167,6 +173,7 @@ DEPENDENCIES
   capybara
   jeweler (~> 1.8.3)
   json (>= 1.5.1)
+  mongo_mapper
   mongoid (~> 2.4.4)
   oauth (~> 0.4.4)
   oauth2 (~> 0.5.1)

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Noam Ben Ari"]
-  s.date = "2012-04-18"
+  s.date = "2012-04-25"
   s.description = "Provides common authentication needs such as signing in/out, activating by email and resetting password."
   s.email = "nbenari@gmail.com"
   s.extra_rdoc_files = [
@@ -302,7 +302,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/NoamB/sorcery"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.21"
+  s.rubygems_version = "1.8.23"
   s.summary = "Magical authentication for Rails 3 applications"
 
   if s.respond_to? :specification_version then
@@ -311,6 +311,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<oauth>, ["~> 0.4.4"])
       s.add_runtime_dependency(%q<oauth2>, ["~> 0.5.1"])
+      s.add_runtime_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
       s.add_development_dependency(%q<rails>, [">= 3.0.0"])
       s.add_development_dependency(%q<json>, [">= 1.5.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.5.0"])
@@ -323,11 +324,12 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, [">= 0.3.8"])
       s.add_development_dependency(%q<timecop>, [">= 0"])
       s.add_development_dependency(%q<capybara>, [">= 0"])
-      s.add_development_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
+      s.add_development_dependency(%q<mongo_mapper>, [">= 0"])
       s.add_development_dependency(%q<mongoid>, ["~> 2.4.4"])
     else
       s.add_dependency(%q<oauth>, ["~> 0.4.4"])
       s.add_dependency(%q<oauth2>, ["~> 0.5.1"])
+      s.add_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
       s.add_dependency(%q<rails>, [">= 3.0.0"])
       s.add_dependency(%q<json>, [">= 1.5.1"])
       s.add_dependency(%q<rspec>, ["~> 2.5.0"])
@@ -340,12 +342,13 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, [">= 0.3.8"])
       s.add_dependency(%q<timecop>, [">= 0"])
       s.add_dependency(%q<capybara>, [">= 0"])
-      s.add_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
+      s.add_dependency(%q<mongo_mapper>, [">= 0"])
       s.add_dependency(%q<mongoid>, ["~> 2.4.4"])
     end
   else
     s.add_dependency(%q<oauth>, ["~> 0.4.4"])
     s.add_dependency(%q<oauth2>, ["~> 0.5.1"])
+    s.add_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
     s.add_dependency(%q<rails>, [">= 3.0.0"])
     s.add_dependency(%q<json>, [">= 1.5.1"])
     s.add_dependency(%q<rspec>, ["~> 2.5.0"])
@@ -358,7 +361,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<simplecov>, [">= 0.3.8"])
     s.add_dependency(%q<timecop>, [">= 0"])
     s.add_dependency(%q<capybara>, [">= 0"])
-    s.add_dependency(%q<bcrypt-ruby>, ["~> 3.0.0"])
+    s.add_dependency(%q<mongo_mapper>, [">= 0"])
     s.add_dependency(%q<mongoid>, ["~> 2.4.4"])
   end
 end


### PR DESCRIPTION
https://github.com/NoamB/sorcery/issues/266

Fixed bcrypt-ruby dependency problem.
I guess change was here: https://github.com/NoamB/sorcery/commit/95330ded52212752fe0cef9a3d614f719632f16a
(moved bcrypt-ruby from runtime to development)

I tested as below:

```
$ git clone https://github.com/NoamB/sorcery-example-app.git
$ cd sorcery-example-app
```

adding to Gemfile:

```
gem 'sorcery', '0.7.11'
```

```
$ bundle
$ bundle exec rake db:create db:migrate
rake aborted!
no such file to load -- bcrypt
```

change  Gemfile:

```
gem 'sorcery', :path => '/path/to/my-sorcery'
```

Then, the dependency problem seems to be fixed.
