### PR TITLE
create_from provider with block

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -72,6 +72,10 @@ module Sorcery
           #
           # And this will cause 'moishe' to be set as the value of :username field.
           # Note: Be careful. This method skips validations model.
+          # Instead you can pass a block, if the block returns false the user will not be created
+          #
+          #   create_from(provider) {|user| user.some_check }
+          #
           def create_from(provider)
             provider = provider.to_sym
             @provider = Config.send(provider)
@@ -91,11 +95,17 @@ module Sorcery
               attrs.each do |k,v|
                 @user.send(:"#{k}=", v)
               end
+              
+              if block_given?
+                return false unless yield @user
+              end
+              
               @user.save(:validate => false)
               user_class.sorcery_config.authentications_class.create!({config.authentications_user_id_attribute_name => @user.id, config.provider_attribute_name => provider, config.provider_uid_attribute_name => @user_hash[:uid]})
             end
             @user
           end
+          
         end
       end
     end

--- a/spec/rails3/app/controllers/application_controller.rb
+++ b/spec/rails3/app/controllers/application_controller.rb
@@ -186,6 +186,20 @@ class ApplicationController < ActionController::Base
       redirect_to "blu", :alert => "Failed!"
     end
   end
+  
+  def test_create_from_provider_with_block
+    provider = params[:provider]
+    login_from(provider)
+    @user = create_from(provider) do |user|
+      # check uniqueness of username
+      User.where(:username => user.username).empty?
+    end
+    if @user 
+      redirect_to "bla", :notice => "Success!"
+    else
+      redirect_to "blu", :alert => "Failed!"
+    end
+  end
 
   protected
 

--- a/spec/rails3_mongo_mapper/app/controllers/application_controller.rb
+++ b/spec/rails3_mongo_mapper/app/controllers/application_controller.rb
@@ -101,6 +101,20 @@ class ApplicationController < ActionController::Base
     end
   end
   
+  def test_create_from_provider_with_block
+    provider = params[:provider]
+    login_from(provider)
+    @user = create_from(provider) do |user|
+      # check uniqueness of username
+      User.where(:username => user.username).empty?
+    end
+    if @user 
+      redirect_to "bla", :notice => "Success!"
+    else
+      redirect_to "blu", :alert => "Failed!"
+    end
+  end
+  
   protected
   
   

--- a/spec/rails3_mongoid/app/controllers/application_controller.rb
+++ b/spec/rails3_mongoid/app/controllers/application_controller.rb
@@ -106,6 +106,20 @@ class ApplicationController < ActionController::Base
     end
   end
   
+  def test_create_from_provider_with_block
+    provider = params[:provider]
+    login_from(provider)
+    @user = create_from(provider) do |user|
+      # check uniqueness of username
+      User.where(:username => user.username).empty?
+    end
+    if @user 
+      redirect_to "bla", :notice => "Success!"
+    else
+      redirect_to "blu", :alert => "Failed!"
+    end
+  end
+  
   protected
   
   

--- a/spec/shared_examples/controller_oauth2_shared_examples.rb
+++ b/spec/shared_examples/controller_oauth2_shared_examples.rb
@@ -32,6 +32,25 @@ shared_examples_for "oauth2_controller" do
       end.should change(User, :count).by(1)
       User.first.username.should == "Noam Ben Ari"
       User.first.created_at.should_not be_nil
-    end 
+    end
+   
+    describe "with a block" do
+      
+      before(:each) do
+        user = User.new(:username => 'Noam Ben Ari')
+        user.save!(:validate => false)
+        user.authentications.create(:provider => 'twitter', :uid => '456')
+      end
+      
+      it "should not create user" do
+        sorcery_model_property_set(:authentications_class, Authentication)
+        sorcery_controller_external_property_set(:facebook, :user_info_mapping, {:username => "name"})
+        lambda do
+          # test_create_from_provider_with_block in controller will check for uniqueness of username
+          get :test_create_from_provider_with_block, :provider => "facebook"
+        end.should_not change(User, :count)
+      end
+    
+    end
   end
 end

--- a/spec/shared_examples/controller_oauth_shared_examples.rb
+++ b/spec/shared_examples/controller_oauth_shared_examples.rb
@@ -33,5 +33,23 @@ shared_examples_for "oauth_controller" do
       User.first.username.should == "coming soon to sorcery gem: twitter and facebook authentication support."
       User.first.created_at.should_not be_nil
     end
+    
+    describe "with a block" do
+      
+      before(:each) do
+        user = User.new(:username => 'nbenari')
+        user.save!(:validate => false)
+        user.authentications.create(:provider => 'github', :uid => '456')
+      end
+      
+      it "should not create user" do
+        sorcery_model_property_set(:authentications_class, Authentication)
+        sorcery_controller_external_property_set(:twitter, :user_info_mapping, {:username => "screen_name"})
+        lambda do
+          get :test_create_from_provider_with_block, :provider => "twitter"
+        end.should_not change(User, :count)
+      end
+    
+    end
   end
 end


### PR DESCRIPTION
As create from provider doesn't perform any validation, it would be useful to a have a possibility to check the user model before it is saved.

I extended **create_from** with a block variant. The user with all user mapping is passed to the block. If the block returns true it will be created otherwise not.

``` ruby
@user = create_from(provider) do |user|
  user.check_for_some_validations
end
```

I needed this for my application, where the username is unique. Independent if the users register creating their own passwords or use a provider. Otherwise it would be still possible to have two users with the same username, one with a password the other one with a provider authentication.
