### PR TITLE
Using update_attribute instead of calling send and then saving

### DIFF
--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -29,8 +29,7 @@ module Sorcery
           # Resets the failed logins counter.
           # Runs as a hook after a successful login.
           def reset_failed_logins_count!(user, credentials)
-            user.send(:"#{user_class.sorcery_config.failed_logins_count_attribute_name}=", 0)
-            user.save!(:validate => false)
+            user.update_attribute(:"#{user_class.sorcery_config.failed_logins_count_attribute_name}", 0)
           end
         end
       end


### PR DESCRIPTION
Using update_attribute on reset_failed_logins_count! ActiveRecord, MongoMapper and Mongoid, it's more semantic and behaves the same as the code before. As talked about on issue #278.
