### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/lib/sorcery/model/adapters/mongo_mapper.rb
+++ b/lib/sorcery/model/adapters/mongo_mapper.rb
@@ -8,15 +8,13 @@ module Sorcery
           include Sorcery::Model
         end
         
-        #module InstanceMethods
-          def increment(attr)
-            self.class.increment(id, attr => 1)
-          end
+        def increment(attr)
+          self.class.increment(id, attr => 1)
+        end
           
-          def save!(options = {})
-            save(options)
-          end
-        #end
+        def save!(options = {})
+          save(options)
+        end
 
         module ClassMethods
           def credential_regex(credential)


### PR DESCRIPTION
I am getting this error using sorcery with MongoMapper in Rails 3.2.3:

DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in Sorcery::Model::Adapters::MongoMapper instead. (called from include at /Users/nachbar/work/2012/railstest/RMongo/app/models/event.rb:2)

I have also noted this error in several other modules.  In each case, the solution is to follow the instructions, commenting out the definition of the InstanceMethods module.

This change stops this error.  For neatness, you might want to reduce the indentation of the increment and save! methods, but to keep the first commit clean, I did not.  I made those formatting changes in the second commit
