### PR TITLE
Fix broken provider name

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -67,10 +67,10 @@ module Sorcery
             @user_hash = @provider.get_user_hash
             config = user_class.sorcery_config
 
-            user = current_user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider)
-            user.save(:validate => false)
+            authentication = current_user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider)
+            authentication.save(:validate => false)
 
-            return user
+            current_user
           end
 
           # Initialize new user from provider informations.


### PR DESCRIPTION
When I use `add_provider_to_user` to add available provider,
the provider name was set as a module name (such as `Sorcery::Controller::Submodules::External::Providers::Facebook::FacebookClient`) against I expected.

This attribute should be a provider name (such as `'facebook'`).
