### PR TITLE
Do not call save on the model when only a few attributes are being changed.

### DIFF
--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -29,8 +29,7 @@ module Sorcery
           # Resets the failed logins counter.
           # Runs as a hook after a successful login.
           def reset_failed_logins_count!(user, credentials)
-            user.send(:"#{user_class.sorcery_config.failed_logins_count_attribute_name}=", 0)
-            user.save!(:validate => false)
+            user.update_many_attributes(user_class.sorcery_config.failed_logins_count_attribute_name => 0)
           end
         end
       end

--- a/lib/sorcery/model/adapters/active_record.rb
+++ b/lib/sorcery/model/adapters/active_record.rb
@@ -8,11 +8,16 @@ module Sorcery
         end
 
         module InstanceMethods
-          def update_single_attribute(name, value)
-            self.send(:"#{name}=", value)
-            
+          def update_many_attributes(attrs)
+            attrs.each do |name, value|
+              self.send(:"#{name}=", value)
+            end
             primary_key = self.class.primary_key
-            self.class.where(:"#{primary_key}" => self.send(:"#{primary_key}")).update_all(name => value)
+            self.class.where(:"#{primary_key}" => self.send(:"#{primary_key}")).update_all(attrs)
+          end
+
+          def update_single_attribute(name, value)
+            update_many_attributes(name => value)
           end
         end
         

--- a/lib/sorcery/model/adapters/mongo_mapper.rb
+++ b/lib/sorcery/model/adapters/mongo_mapper.rb
@@ -16,6 +16,10 @@ module Sorcery
           def save!(options = {})
             save(options)
           end
+
+          def update_many_attributes(attrs)
+            update_attributes(attrs)
+          end
         end
 
         module ClassMethods

--- a/lib/sorcery/model/adapters/mongoid.rb
+++ b/lib/sorcery/model/adapters/mongoid.rb
@@ -11,11 +11,17 @@ module Sorcery
           def increment(attr)
             self.inc(attr,1)
           end
-          
+
+          def update_many_attributes(attrs)
+            attrs.each do |name, value|
+              attrs[name] = value.utc if value.is_a?(ActiveSupport::TimeWithZone)
+              self.send(:"#{name}=", value)
+            end
+            self.class.where(:_id => self.id).update_all(attrs)
+          end
+
           def update_single_attribute(name, value)
-            value = value.utc if value.is_a?(ActiveSupport::TimeWithZone)
-            self.send(:"#{name}=", value)
-            self.class.where(:_id => self.id).update_all(name => value)
+            update_many_attributes(name => value)
           end
         end
 

--- a/lib/sorcery/model/submodules/remember_me.rb
+++ b/lib/sorcery/model/submodules/remember_me.rb
@@ -49,17 +49,15 @@ module Sorcery
           # You shouldn't really use this one yourself - it's called by the controller's 'remember_me!' method.
           def remember_me!
             config = sorcery_config
-            self.send(:"#{config.remember_me_token_attribute_name}=", TemporaryToken.generate_random_token)
-            self.send(:"#{config.remember_me_token_expires_at_attribute_name}=", Time.now.in_time_zone + config.remember_me_for)
-            self.save!(:validate => false)
+            self.update_many_attributes(config.remember_me_token_attribute_name => TemporaryToken.generate_random_token,
+                                        config.remember_me_token_expires_at_attribute_name => Time.now.in_time_zone + config.remember_me_for)
           end
           
           # You shouldn't really use this one yourself - it's called by the controller's 'forget_me!' method.
           def forget_me!
             config = sorcery_config
-            self.send(:"#{config.remember_me_token_attribute_name}=", nil)
-            self.send(:"#{config.remember_me_token_expires_at_attribute_name}=", nil)
-            self.save!(:validate => false)
+            self.update_many_attributes(config.remember_me_token_attribute_name => nil,
+                                        config.remember_me_token_expires_at_attribute_name => nil)
           end
         end
       end

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -96,11 +96,11 @@ module Sorcery
             config = sorcery_config
             # hammering protection
             return false if config.reset_password_time_between_emails && self.send(config.reset_password_email_sent_at_attribute_name) && self.send(config.reset_password_email_sent_at_attribute_name) > config.reset_password_time_between_emails.ago.utc
-            self.send(:"#{config.reset_password_token_attribute_name}=", TemporaryToken.generate_random_token)
-            self.send(:"#{config.reset_password_token_expires_at_attribute_name}=", Time.now.in_time_zone + config.reset_password_expiration_period) if config.reset_password_expiration_period
-            self.send(:"#{config.reset_password_email_sent_at_attribute_name}=", Time.now.in_time_zone)
+            attributes = {config.reset_password_token_attribute_name => TemporaryToken.generate_random_token,
+                          config.reset_password_email_sent_at_attribute_name => Time.now.in_time_zone}
+            attributes[config.reset_password_token_expires_at_attribute_name] = Time.now.in_time_zone + config.reset_password_expiration_period if config.reset_password_expiration_period
             self.class.transaction do
-              self.save!(:validate => false)
+              self.update_many_attributes(attributes)
               generic_send_email(:reset_password_email_method_name, :reset_password_mailer) unless config.reset_password_mailer_disabled
             end
           end


### PR DESCRIPTION
Hello Noam,

Sorry for the several pull requests. This one is the cleanest one so far. It works on top of master, and not a tag and **all the tests that passed before still pass now, including mongo_mapper**.

In our user model we have a couple of serialized attributes and Rails apparently always saves serialized attributes when calling save because it cannot keep track of whether they are dirty or not (I think). This meant that in many requests that used Sorcery, we end up doing a rather big update to a database. Also, we have some after filters that were unexpectedly run due to Sorcery calling save on the model.

We noticed this didn't always happen because some modules of Sorcery use update_single_attribute. We wrote a similar but more generic update_many_attributes and made sure it is used instead of save everywhere where it makes sense (it doesn't when changing the password or creating a new user).

We ran all the tests before and after this commit and we got the same amount of failures (everything passed but three oauth related tests). We also made sure we ran all the touched lines by manual testing from our application that is using Sorcery. **We run this code in production for a few weeks already**

We did this change pair-programming, @dmagliola and I.

Please, let me know if there are any changes you require to consider this commit.
