### PR TITLE
Bugfix in user loading when restoring from session

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -110,7 +110,7 @@ module Sorcery
       end
 
       def login_from_session
-        @current_user = (user_class.find_by_id(session[:user_id]) if session[:user_id]) || false
+        @current_user = (user_class.find(session[:user_id]) if session[:user_id]) || false
       end
 
       def after_login!(user, credentials = [])


### PR DESCRIPTION
When loading the user from a session you call `find_by_id` on the model class. But the primary key is not necessarily named `id` which leads to an „method find_by_id not found“ exception when calling `current_user`. Calling `find` instead is better, because it always works on the primary key.
