### PR TITLE
add process_callback to add_provider_to_user method

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -77,8 +77,13 @@ module Sorcery
             @user_hash = @provider.get_user_hash
             config = user_class.sorcery_config
 
-            user = current_user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider_name.to_s)
-            user.save(:validate => false)
+            # first check to see if user has a particular authentication already
+            unless (current_user.send(config.authentications_class.to_s.downcase.pluralize).send("find_by_#{config.provider_attribute_name}_and_#{config.provider_uid_attribute_name}", provider, @user_hash[:uid]))
+              user = current_user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider)
+              user.save(:validate => false)
+            else
+              user = false
+            end
 
             return user
           end


### PR DESCRIPTION
Hi! Needed to process the callback first before referencing the get_user_hash otherwise the access_token was nil. This method should now be working. Also added in the check to make sure the authentication doesn't already exist.
