### PR TITLE
Updated the BCrypt provider to alias "stretches" to "cost".

### DIFF
--- a/lib/sorcery/crypto_providers/bcrypt.rb
+++ b/lib/sorcery/crypto_providers/bcrypt.rb
@@ -48,6 +48,7 @@ module Sorcery
           @cost ||= 10
         end
         attr_writer :cost
+        alias :stretches :cost
         alias :stretches= :cost=
         
         # Creates a BCrypt hash for the password passed.

--- a/spec/sorcery_crypto_providers_spec.rb
+++ b/spec/sorcery_crypto_providers_spec.rb
@@ -181,6 +181,15 @@ describe "Crypto Providers wrappers" do
     it "matches? returns false when no match" do
       Sorcery::CryptoProviders::BCrypt.matches?(@digest, 'Some Dude').should be_false
     end
+
+    it "respond_to?(:stretches) returns true" do
+      Sorcery::CryptoProviders::BCrypt.respond_to?(:stretches).should be_true
+    end
+
+    it "sets cost when stretches is set" do
+      Sorcery::CryptoProviders::BCrypt.stretches = 4
+      Sorcery::CryptoProviders::BCrypt.cost.should == 4
+    end
     
   end
   


### PR DESCRIPTION
When setting up encryption Sorcery checks if the provider responds to "stretches".
Since the BCrypt provider only responded to "stretches=" the cost provided in the Sorcery config was not passed on to the provider.
