### PR TITLE
When having logged in a user should not be redirected to a post, put or delete URL

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -21,7 +21,7 @@ module Sorcery
       # If all attempts to auto-login fail, the failure callback will be called.
       def require_login
         if !logged_in?
-          session[:return_to_url] = request.url if Config.save_return_to_url
+          session[:return_to_url] = request.url if Config.save_return_to_url && request.get?
           self.send(Config.not_authenticated_action)
         end
       end

--- a/spec/rails3/spec/controller_spec.rb
+++ b/spec/rails3/spec/controller_spec.rb
@@ -141,6 +141,13 @@ describe ApplicationController do
       response.should redirect_to("http://test.host/")
     end
     
+    it "require_login before_filter should not save the url that the user originally wanted upon all non-get http methods" do
+      [:post, :put, :delete].each do |m|
+        self.send(m, :some_action)
+        session[:return_to_url].should be_nil
+      end
+    end
+    
     it "on successful login the user should be redirected to the url he originally wanted" do
       session[:return_to_url] = "http://test.host/some_action"
       post :test_return_to, :username => 'gizmo', :password => 'secret'

--- a/spec/rails3_mongo_mapper/spec/controller_spec.rb
+++ b/spec/rails3_mongo_mapper/spec/controller_spec.rb
@@ -141,6 +141,13 @@ describe ApplicationController do
       response.should redirect_to("http://test.host/")
     end
     
+    it "require_login before_filter should not save the url that the user originally wanted upon all non-get http methods" do
+      [:post, :put, :delete].each do |m|
+        self.send(m, :some_action)
+        session[:return_to_url].should be_nil
+      end
+    end
+    
     it "on successful login the user should be redirected to the url he originally wanted" do
       session[:return_to_url] = "http://test.host/some_action"
       post :test_return_to, :username => 'gizmo', :password => 'secret'

--- a/spec/rails3_mongoid/spec/controller_spec.rb
+++ b/spec/rails3_mongoid/spec/controller_spec.rb
@@ -152,6 +152,13 @@ describe ApplicationController do
       response.should redirect_to("http://test.host/")
     end
     
+    it "require_login before_filter should not save the url that the user originally wanted upon all non-get http methods" do
+      [:post, :put, :delete].each do |m|
+        self.send(m, :some_action)
+        session[:return_to_url].should be_nil
+      end
+    end
+    
     it "on successful login the user should be redirected to the url he originally wanted" do
       session[:return_to_url] = "http://test.host/some_action"
       post :test_return_to, :username => 'gizmo', :password => 'secret'


### PR DESCRIPTION
When a user is not authenticated and performs a post, put or delete which requires authentication the user is first redirected to the login form. After a successful login the user is accordingly redirected to the original URL, however this URL was not accessible via a GET request.

This pull request makes sure session[:return_to_url] is only set upon a GET request. This way the redirect_back_or_to function will not redirect you to a unsupported location.

Must say, I'd much rather like to replay the original request instead of preventing a GET to it. The only way I can think of is to make use of Javascript, which is definitely not the way to go.
