### PR TITLE
Sorcery fails silently and doesn't hash passwords when encryption algorithm is misconfigured

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -266,7 +266,7 @@ module Sorcery
       
       def encryption_algorithm=(algo)
         @encryption_algorithm = algo
-        @encryption_provider = case @encryption_algorithm
+        @encryption_provider = case @encryption_algorithm.to_sym
         when :none   then nil
         when :md5    then CryptoProviders::MD5
         when :sha1   then CryptoProviders::SHA1
@@ -275,6 +275,7 @@ module Sorcery
         when :aes256 then CryptoProviders::AES256
         when :bcrypt then CryptoProviders::BCrypt
         when :custom then @custom_encryption_provider
+        else raise ArgumentError.new("Encryption algorithm supplied, #{algo}, is invalid")
         end
       end
       


### PR DESCRIPTION
I found that when the value of encryption is set to a string instead of a symbol, Sorcery will fail silently and not hash passwords in the database.  Sorcery will also fail silently when configured with an encryption algorithm it doesn't know about.

Specifically, I had a project where I configured Sorcery with a string not a symbol: `user.encryption_algorithm = 'sha1'`.  The passwords were left unhashed in the database, and Sorcery gave me no indication that this was the case.

I modified the encryption algorithm switch statement to accept strings as well as symbols and to raise an error if the algorithm is unknown. 
