### PR TITLE
Fix a RecordNotFound exception on login_from_session

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -112,7 +112,11 @@ module Sorcery
       def login_from_session
         @current_user = (user_class.find(session[:user_id]) if session[:user_id]) || false
       rescue => exception
-        return false if exception.is_a?(ActiveRecord::RecordNotFound)
+        if exception.is_a?(ActiveRecord::RecordNotFound)
+          reset_session
+          return false
+        end
+        
         return false if defined?(Mongoid) and exception.is_a?(Mongoid::Errors::DocumentNotFound)
         raise exception
       end


### PR DESCRIPTION
If user no longer exists but session is still active, an exception is raised. This should prevent it.
