### PR TITLE
Fixed an issue with mailers not inheriting directly from ActionMailer::Base

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -17,39 +17,39 @@ module Sorcery
               include InstanceMethods
               include TemporaryToken
             end
-            
+
             include_required_submodules!
 
             # This runs the options block set in the initializer on the model class.
             ::Sorcery::Controller::Config.user_config.tap{|blk| blk.call(@sorcery_config) if blk}
-            
+
             init_mongoid_support! if defined?(Mongoid) and self.ancestors.include?(Mongoid::Document)
             init_mongo_mapper_support! if defined?(MongoMapper) and self.ancestors.include?(MongoMapper::Document)
 
             init_orm_hooks!
-            
+
             @sorcery_config.after_config << :add_config_inheritance if @sorcery_config.subclasses_inherit_config
             @sorcery_config.after_config.each { |c| send(c) }
           end
-          
+
           protected
-          
-          # includes required submodules into the model class, 
+
+          # includes required submodules into the model class,
           # which usually is called User.
           def include_required_submodules!
             self.class_eval do
               @sorcery_config.submodules = ::Sorcery::Controller::Config.submodules
               @sorcery_config.submodules.each do |mod|
                 begin
-                  include Submodules.const_get(mod.to_s.split("_").map {|p| p.capitalize}.join("")) 
+                  include Submodules.const_get(mod.to_s.split("_").map {|p| p.capitalize}.join(""))
                 rescue NameError
-                  # don't stop on a missing submodule. Needed because some submodules are only defined 
+                  # don't stop on a missing submodule. Needed because some submodules are only defined
                   # in the controller side.
                 end
               end
             end
           end
-          
+
           # defines mongoid fields on the model class,
           # using 1.8.x hash syntax to perserve compatibility.
           def init_mongoid_support!
@@ -62,7 +62,7 @@ module Sorcery
               field sorcery_config.salt_attribute_name,             :type => String
             end
           end
-          
+
           # defines mongo_mapper fields on the model class,
           def init_mongo_mapper_support!
             self.class_eval do
@@ -91,13 +91,13 @@ module Sorcery
         end
       end
     end
-    
+
     module ClassMethods
       # Returns the class instance variable for configuration, when called by the class itself.
       def sorcery_config
         @sorcery_config
       end
-      
+
       # The default authentication method.
       # Takes a username and password,
       # Finds the user by the username and compares the user's password to the one supplied to the method.
@@ -112,17 +112,17 @@ module Sorcery
         _salt = user.send(@sorcery_config.salt_attribute_name) if user && !@sorcery_config.salt_attribute_name.nil? && !@sorcery_config.encryption_provider.nil?
         user if user && @sorcery_config.before_authenticate.all? {|c| user.send(c)} && credentials_match?(user.send(@sorcery_config.crypted_password_attribute_name),credentials[1],_salt)
       end
-      
+
       # encrypt tokens using current encryption_provider.
       def encrypt(*tokens)
         return tokens.first if @sorcery_config.encryption_provider.nil?
-        
+
         set_encryption_attributes()
 
         CryptoProviders::AES256.key = @sorcery_config.encryption_key
         @sorcery_config.encryption_provider.encrypt(*tokens)
       end
-      
+
       protected
 
       def set_encryption_attributes()
@@ -135,7 +135,7 @@ module Sorcery
         return crypted == tokens.join if @sorcery_config.encryption_provider.nil?
         @sorcery_config.encryption_provider.matches?(crypted, *tokens)
       end
-      
+
       def add_config_inheritance
         self.class_eval do
           def self.inherited(subclass)
@@ -149,23 +149,23 @@ module Sorcery
           end
         end
       end
-      
+
     end
-    
+
     module InstanceMethods
       # Returns the class instance variable for configuration, when called by an instance.
       def sorcery_config
         self.class.sorcery_config
       end
-      
+
       # identifies whether this user is regular, i.e. we hold his credentials in our db,
       # or that he is external, and his credentials are saved elsewhere (twitter/facebook etc.).
       def external?
         send(sorcery_config.crypted_password_attribute_name).nil?
       end
-      
+
       protected
-      
+
       # creates new salt and saves it.
       # encrypts password with salt and saves it.
       def encrypt_password
@@ -178,29 +178,29 @@ module Sorcery
         config = sorcery_config
         self.send(:"#{config.password_attribute_name}=", nil)
       end
-      
+
       # calls the requested email method on the configured mailer
       # supports both the ActionMailer 3 way of calling, and the plain old Ruby object way.
       def generic_send_email(method, mailer)
         config = sorcery_config
         mail = config.send(mailer).send(config.send(method),self)
-        if defined?(ActionMailer) and config.send(mailer).superclass == ActionMailer::Base
+        if defined?(ActionMailer) and config.send(mailer).kind_of?(Class) and config.send(mailer) < ActionMailer::Base
           mail.deliver
         end
       end
     end
 
     # Each class which calls 'activate_sorcery!' receives an instance of this class.
-    # Every submodule which gets loaded may add accessors to this class so that all 
+    # Every submodule which gets loaded may add accessors to this class so that all
     # options will be configured from a single place.
     class Config
 
       attr_accessor :username_attribute_names,           # change default username attribute, for example, to use :email
                                                         # as the login.
-                                                        
+
                     :password_attribute_name,           # change *virtual* password attribute, the one which is used
                                                         # until an encrypted one is generated.
-                                                        
+
                     :email_attribute_name,              # change default email attribute.
 
                     :downcase_username_before_authenticating, # downcase the username before trying to authenticate, default is false
@@ -211,17 +211,17 @@ module Sorcery
                     :stretches,                         # how many times to apply encryption to the password.
                     :encryption_key,                    # encryption key used to encrypt reversible encryptions such as
                                                         # AES256.
-                                                        
+
                     :subclasses_inherit_config,         # make this configuration inheritable for subclasses. Useful for
                                                         # ActiveRecord's STI.
-                    
+
                     :submodules,                        # configured in config/application.rb
                     :before_authenticate,               # an array of method names to call before authentication
                                                         # completes. used internally.
-                                                        
+
                     :after_config                       # an array of method names to call after configuration by user.
                                                         # used internally.
-                    
+
       attr_reader   :encryption_provider,               # change default encryption_provider.
                     :custom_encryption_provider,        # use an external encryption class.
                     :encryption_algorithm               # encryption algorithm name. See 'encryption_algorithm=' below
@@ -247,23 +247,23 @@ module Sorcery
           :@after_config                         => []
         }
         reset!
-      end     
-           
+      end
+
       # Resets all configuration options to their default values.
       def reset!
         @defaults.each do |k,v|
           instance_variable_set(k,v)
-        end       
+        end
       end
-      
+
       def username_attribute_names=(fields)
         @username_attribute_names = fields.kind_of?(Array) ? fields : [fields]
       end
-      
+
       def custom_encryption_provider=(provider)
         @custom_encryption_provider = @encryption_provider = provider
       end
-      
+
       def encryption_algorithm=(algo)
         @encryption_algorithm = algo
         @encryption_provider = case @encryption_algorithm.to_sym
@@ -278,8 +278,8 @@ module Sorcery
         else raise ArgumentError.new("Encryption algorithm supplied, #{algo}, is invalid")
         end
       end
-      
+
     end
-    
+
   end
 end


### PR DESCRIPTION
The inheritance verification failed when a mailer class didn't inherit directly from ActionMailer::Base

ex:

```
class GenericMailer < ActionMailer::Base
  ...
end

class UserMailer < GenericMailer
  ...
end
```

Mails would not get sent because of how the inheritance was checked.
