### PR TITLE
Allow loading the engine in Rails 4

### DIFF
--- a/lib/sorcery.rb
+++ b/lib/sorcery.rb
@@ -79,5 +79,5 @@ module Sorcery
     MongoMapper::Document.send(:plugin, Sorcery::Model::Adapters::MongoMapper)
   end
 
-  require 'sorcery/engine' if defined?(Rails) && Rails::VERSION::MAJOR == 3
+  require 'sorcery/engine' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 end


### PR DESCRIPTION
Rails 4 will be almost compatible with rails 3 regarding engines, so you can relax the major version requirements.
