### PR TITLE
Its bad idea, to raise exception, if no "User" found with such id

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -112,7 +112,7 @@ module Sorcery
       end
 
       def login_from_session
-        @current_user = (user_class.find(session[:user_id]) if session[:user_id]) || false
+        @current_user = (user_class.where(:id =>session[:user_id]).first if session[:user_id]) || false
       rescue => exception
         return false if defined?(Mongoid) and exception.is_a?(Mongoid::Errors::DocumentNotFound)
         return false if defined?(ActiveRecord) and exception.is_a?(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
For example, u logged, on the site, then destroy your auth model(User for simplicity), 
if user try go to website, rails will render 500 error, cause find raise exception "No record found", 
better user experience is just redirect to not_authenticated path.
