### PR TITLE
added a config option for the :remember_me module cookie to be settable via AJAX

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -26,6 +26,13 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.cookie_domain =
 
+  
+  # -- remember_me --
+  # allow the remember_me cookie to settable through AJAX
+  # Default: `true`
+  #
+  # user.remember_me_httponly =
+  
 
   # -- session timeout --
   # How long in seconds to keep the session alive.

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -8,6 +8,15 @@ module Sorcery
       module RememberMe
         def self.included(base)
           base.send(:include, InstanceMethods)
+          Config.module_eval do
+            class << self
+              attr_accessor :remember_me_httponly
+              def merge_remember_me_defaults!
+                @defaults.merge!(:@remember_me_httponly => true)
+              end
+            end
+            merge_remember_me_defaults!
+          end
           Config.login_sources << :login_from_cookie
           Config.after_login << :remember_me_if_asked_to
           Config.after_logout << :forget_me!
@@ -60,7 +69,7 @@ module Sorcery
             cookies.signed[:remember_me_token] = {
               :value => user.send(user.sorcery_config.remember_me_token_attribute_name),
               :expires => user.send(user.sorcery_config.remember_me_token_expires_at_attribute_name),
-              :httponly => true,
+              :httponly => Config.remember_me_httponly,
               :domain => Config.cookie_domain
             }
           end


### PR DESCRIPTION
i'm building an ember.js app on rails and the remember_me cookie wasn't being kept after a successful AJAX session request. i found that if i overrode the :remember_me option for http_only i was able stay remembered, so i added it as an option to the initializer.
