### PR TITLE
Bugfix: Infinite Loop in http basic auth

### DIFF
--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -58,7 +58,7 @@ module Sorcery
               while current_controller != ActionController::Base
                 result = Config.controller_to_realm_map[current_controller.controller_name]
                 return result if result
-                current_controller = self.class.superclass
+                current_controller = current_controller.superclass
               end
               nil
             else


### PR DESCRIPTION
If the current controller couldn't be found in the 
Config.controller_to_realm_map and the controller
didn't inherit from ActionController::Base, 
# realm_name_by_controller would enter an infinite loop.

This commit makes the loop actually go through the 
controller's ancestors, where it will eventually reach 
ActionController::Base
