### PR TITLE
remove core from the submodule list

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -47,7 +47,7 @@ module Sorcery
 
         if submodules
           submodules.each do |submodule|
-            unless submodule == "http_basic_auth" || submodule == "session_timeout"
+            unless submodule == "http_basic_auth" || submodule == "session_timeout" || submodule == "core"
               migration_template "migration/#{submodule}.rb", "db/migrate/sorcery_#{submodule}.rb"
             end
           end


### PR DESCRIPTION
Since sorcery_core migration is always created. This will prevent this error "Another migration is already named sorcery_core" from happening in the future if you include it in the submodule list.

Railscast has that in it's demo, it's probably best to remove this so no one else gets burned. http://railscasts.com/episodes/283-authentication-with-sorcery

Seemed to happen to someone else here: https://github.com/NoamB/sorcery/issues/338
