### PR TITLE
turn session into hash before reset due to both sessions being reset (old and new)

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -32,9 +32,9 @@ module Sorcery
         @current_user = nil
         user = user_class.authenticate(*credentials)
         if user
-          old_session = session.dup
+          old_session = session.dup.to_hash
           reset_session # protect from session fixation attacks
-          old_session.to_hash.each_pair do |k,v|
+          old_session.each_pair do |k,v|
             session[k.to_sym] = v
           end
           auto_login(user)


### PR DESCRIPTION
We found that both the existing session and the new session get reset when duping. By converting it to a hash before resetting we don't run into the same problem.

Hats off to @mvandenbeuken for finding the bug & the fix.
