### PR TITLE
Reloads user object when validation fails on change_password!

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -109,7 +109,12 @@ module Sorcery
           def change_password!(new_password)
             clear_reset_password_token
             self.send(:"#{sorcery_config.password_attribute_name}=", new_password)
-            save
+            if self.valid?
+              save
+            else
+              reload
+              false
+            end
           end
 
           protected


### PR DESCRIPTION
Particularly useful when password reset form uses user object. The reset token should not be nil when validation fails. This way password reset form can safely use user.reset_password_token to identify the user.
