### PR TITLE
Configuration for skipping session data restoration after login

### DIFF
--- a/spec/Gemfile.lock
+++ b/spec/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       oauth2 (~> 0.8.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     abstract (1.0.0)
     actionmailer (3.0.3)

--- a/spec/rails3/spec/controller_spec.rb
+++ b/spec/rails3/spec/controller_spec.rb
@@ -103,6 +103,24 @@ describe ApplicationController do
       session[:user_id].should == @user.id
     end
 
+    it "login(username,password) should return the user when success, set the session with user.id and maintain the old session data" do
+      session[:foo] = "Bar"
+      get :test_login, :username => 'gizmo', :password => 'secret'
+      assigns[:user].should == @user
+      session[:user_id].should == @user.id
+      session[:foo].should == "Bar"
+    end
+
+
+    it "login(username,password) should return the user when success, set the session with user.id and discard the old session data when :skip_session_data_restoration config is true" do
+      session[:foo] = "Bar"
+      Sorcery::Controller::Config.skip_session_data_restoration = true
+      get :test_login, :username => 'gizmo', :password => 'secret'
+      assigns[:user].should == @user
+      session[:user_id].should == @user.id
+      session[:foo].should be_nil
+    end
+
     it "logout should clear the session" do
       cookies[:remember_me_token] = nil
       session[:user_id] = @user.id


### PR DESCRIPTION
I was having some performance issue with the code that restores the session data after the login. My app does not need to save and restore the session data, so I created a configuration that allows it to skip this behaviour.
