### PR TITLE
Allow nested hashes as the target of External's user_info_mapping

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -153,11 +153,20 @@ module Sorcery
           def user_attrs(user_info_mapping, user_hash)
             attrs = {}
             user_info_mapping.each do |k,v|
+              target = attrs
+
+              if (karr = k.to_s.split('/')).size > 1
+                k = karr.pop
+                karr.each do |kpart|
+                  target = target[kpart] ||= {}
+                end
+              end
+
               if (varr = v.split("/")).size > 1
                 attribute_value = varr.inject(user_hash[:user_info]) {|hash, value| hash[value]} rescue nil
-                attribute_value.nil? ? attrs : attrs.merge!(k => attribute_value)
+                attribute_value.nil? ? target : target.merge!(k => attribute_value)
               else
-                attrs.merge!(k => user_hash[:user_info][v])
+                target.merge!(k => user_hash[:user_info][v])
               end
             end
             return attrs


### PR DESCRIPTION
The `user_info_mapping` hash allows you to embed slashes in the values such as

```
{:username => "user/name"}
```

This PR allows you to add slashes to the keys as well, which will build nested hashes instead of single keys.

We need this in order to accept external registrations via facebook, where the email goes on the User model but the first_name and last_name go on a Person model.
