### PR TITLE
Ability to authorize with oauth providers for multi-domain sites

### DIFF
--- a/lib/sorcery.rb
+++ b/lib/sorcery.rb
@@ -31,6 +31,7 @@ module Sorcery
           autoload :Oauth2, 'sorcery/controller/submodules/external/protocols/oauth2'
         end
         module Providers
+          autoload :Base, 'sorcery/controller/submodules/external/providers/base'
           autoload :Twitter, 'sorcery/controller/submodules/external/providers/twitter'
           autoload :Facebook, 'sorcery/controller/submodules/external/providers/facebook'
           autoload :Github, 'sorcery/controller/submodules/external/providers/github'

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -33,13 +33,14 @@ module Sorcery
           # after authentication the user is redirected to the callback defined in the provider config
           def login_at(provider_name, args = {})
             provider = Config.send(provider_name)
-            if provider.callback_url.present? && provider.callback_url[0] == '/'
+            provider.original_callback_url ||= provider.callback_url
+            if provider.original_callback_url.present? && provider.original_callback_url[0] == '/'
               uri = URI.parse(request.url.gsub(/\?.*$/,''))
               uri.path = ''
               uri.query = nil
               uri.scheme = 'https' if(request.env['HTTP_X_FORWARDED_PROTO'] == 'https')
               host = uri.to_s
-              provider.callback_url = "#{host}#{provider.callback_url}"
+              provider.callback_url = "#{host}#{provider.original_callback_url}"
             end
             if provider.has_callback?
               redirect_to provider.login_url(params,session)

--- a/lib/sorcery/controller/submodules/external/providers/base.rb
+++ b/lib/sorcery/controller/submodules/external/providers/base.rb
@@ -1,0 +1,21 @@
+module Sorcery
+  module Controller
+    module Submodules
+      module External
+        module Providers
+          module Base
+            module BaseClient
+              def self.included(base)
+                base.module_eval do
+                  class << self
+                    attr_accessor :original_callback_url
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sorcery/controller/submodules/external/providers/facebook.rb
+++ b/lib/sorcery/controller/submodules/external/providers/facebook.rb
@@ -16,7 +16,7 @@ module Sorcery
               base.module_eval do
                 class << self
                   attr_reader :facebook                           # access to facebook_client.
-                  
+
                   def merge_facebook_defaults!
                     @defaults.merge!(:@facebook => FacebookClient)
                   end
@@ -25,8 +25,9 @@ module Sorcery
                 update!
               end
             end
-          
+
             module FacebookClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,
@@ -40,7 +41,7 @@ module Sorcery
                 attr_reader   :access_token
 
                 include Protocols::Oauth2
-            
+
                 def init
                   @site           = "https://graph.facebook.com"
                   @user_info_path = "/me"
@@ -52,7 +53,7 @@ module Sorcery
                   @parse          = :query
                   @param_name     = "access_token"
                 end
-                
+
                 def get_user_hash
                   user_hash = {}
                   response = @access_token.get(@user_info_path)
@@ -60,11 +61,11 @@ module Sorcery
                   user_hash[:uid] = user_hash[:user_info]['id']
                   user_hash
                 end
-                
+
                 def has_callback?
                   true
                 end
-                
+
                 # calculates and returns the url to which the user should be redirected,
                 # to get authenticated at the external provider's site.
                 def login_url(params,session)
@@ -84,13 +85,13 @@ module Sorcery
                   args.merge!({:code => params[:code]}) if params[:code]
                   @access_token = self.get_access_token(args, options)
                 end
-                
+
               end
               init
             end
-            
+
           end
-        end    
+        end
       end
     end
   end

--- a/lib/sorcery/controller/submodules/external/providers/github.rb
+++ b/lib/sorcery/controller/submodules/external/providers/github.rb
@@ -27,6 +27,7 @@ module Sorcery
             end
 
             module GithubClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,

--- a/lib/sorcery/controller/submodules/external/providers/google.rb
+++ b/lib/sorcery/controller/submodules/external/providers/google.rb
@@ -27,6 +27,7 @@ module Sorcery
             end
 
             module GoogleClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,

--- a/lib/sorcery/controller/submodules/external/providers/linkedin.rb
+++ b/lib/sorcery/controller/submodules/external/providers/linkedin.rb
@@ -15,7 +15,7 @@ module Sorcery
             def self.included(base)
               base.module_eval do
                 class << self
-                  attr_reader :linkedin                        
+                  attr_reader :linkedin
 
                   def merge_linkedin_defaults!
                     @defaults.merge!(:@linkedin => LinkedinClient)
@@ -25,8 +25,9 @@ module Sorcery
                 update!
               end
             end
-            
+
             module LinkedinClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,
@@ -42,14 +43,14 @@ module Sorcery
                 attr_reader   :access_token
 
                 include Protocols::Oauth1
-        
+
                 # Override included get_consumer method to provide authorize_path
                 def get_consumer
                   # Add access permissions to request token path
                   @configuration[:request_token_path] += "?scope=" + self.access_permissions.join('+') unless self.access_permissions.blank? or @configuration[:request_token_path].include? "?scope="
                   ::OAuth::Consumer.new(@key, @secret, @configuration)
                 end
-                
+
                 def init
                   @configuration = {
                     site: "https://api.linkedin.com",
@@ -59,7 +60,7 @@ module Sorcery
                   }
                   @user_info_path = "/v1/people/~"
                 end
-                
+
                 def get_user_hash
                   user_hash = {}
                   fields = self.user_info_fields.join(',')
@@ -68,11 +69,11 @@ module Sorcery
                   user_hash[:uid] = user_hash[:user_info]['id'].to_s
                   user_hash
                 end
-                
+
                 def has_callback?
                   true
                 end
-                
+
                 # calculates and returns the url to which the user should be redirected,
                 # to get authenticated at the external provider's site.
                 def login_url(params,session)
@@ -81,7 +82,7 @@ module Sorcery
                   session[:request_token_secret]  = req_token.secret
                   self.authorize_url({:request_token => req_token.token, :request_token_secret => req_token.secret})
                 end
-                
+
                 # tries to login the user from access token
                 def process_callback(params,session)
                   args = {}
@@ -90,7 +91,7 @@ module Sorcery
                   @access_token = self.get_access_token(args)
                 end
 
-              end  
+              end
               init
             end
           end

--- a/lib/sorcery/controller/submodules/external/providers/liveid.rb
+++ b/lib/sorcery/controller/submodules/external/providers/liveid.rb
@@ -27,6 +27,7 @@ module Sorcery
             end
 
             module LiveidClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,

--- a/lib/sorcery/controller/submodules/external/providers/twitter.rb
+++ b/lib/sorcery/controller/submodules/external/providers/twitter.rb
@@ -18,7 +18,7 @@ module Sorcery
                   attr_reader :twitter
                   # def twitter(&blk) # allows block syntax.
                   #   yield @twitter
-                  # end                           
+                  # end
 
                   def merge_twitter_defaults!
                     @defaults.merge!(:@twitter => TwitterClient)
@@ -28,8 +28,9 @@ module Sorcery
                 update!
               end
             end
-            
+
             module TwitterClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,
@@ -40,18 +41,18 @@ module Sorcery
                 attr_reader   :access_token
 
                 include Protocols::Oauth1
-				
+
 				        # Override included get_consumer method to provide authorize_path
 				        def get_consumer
                   ::OAuth::Consumer.new(@key, @secret, :site => @site, :authorize_path => "/oauth/authenticate")
                 end
-                
+
                 def init
                   @site           = "https://api.twitter.com"
                   @user_info_path = "/1/account/verify_credentials.json"
                   @user_info_mapping = {}
                 end
-                
+
                 def get_user_hash
                   user_hash = {}
                   response = @access_token.get(@user_info_path)
@@ -59,11 +60,11 @@ module Sorcery
                   user_hash[:uid] = user_hash[:user_info]['id'].to_s
                   user_hash
                 end
-                
+
                 def has_callback?
                   true
                 end
-                
+
                 # calculates and returns the url to which the user should be redirected,
                 # to get authenticated at the external provider's site.
                 def login_url(params,session)
@@ -72,7 +73,7 @@ module Sorcery
                   session[:request_token_secret]  = req_token.secret
                   self.authorize_url({:request_token => req_token.token, :request_token_secret => req_token.secret})
                 end
-                
+
                 # tries to login the user from access token
                 def process_callback(params,session)
                   args = {}
@@ -81,7 +82,7 @@ module Sorcery
                   @access_token = self.get_access_token(args)
                 end
 
-              end  
+              end
               init
             end
           end

--- a/lib/sorcery/controller/submodules/external/providers/vk.rb
+++ b/lib/sorcery/controller/submodules/external/providers/vk.rb
@@ -27,6 +27,7 @@ module Sorcery
             end
 
             module VkClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,

--- a/lib/sorcery/controller/submodules/external/providers/xing.rb
+++ b/lib/sorcery/controller/submodules/external/providers/xing.rb
@@ -27,6 +27,7 @@ module Sorcery
             end
 
             module XingClient
+              include Base::BaseClient
               class << self
                 attr_accessor :key,
                               :secret,


### PR DESCRIPTION
Some oauth providers return a 401 error for sites with multiple domain names. At the moment Sorcery uses only one URL for each provider, even if the initializer have a relative URL for them, becouse it saves URL with the first domain name used for authentication. If one will try to authenticate from another domain name for this site Sorcery will use previous stored callback URL for this provider.
