### PR TITLE
Make sure @current_user isn't nil for after_logout!

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -51,7 +51,8 @@ module Sorcery
       # Resets the session and runs hooks before and after.
       def logout
         if logged_in?
-          before_logout!(current_user)
+          @current_user = current_user if @current_user.nil?
+          before_logout!(@current_user)
           reset_session
           after_logout!
           @current_user = nil


### PR DESCRIPTION
I came across the situation where @current_user was nil resulting in the remember_me submodule failing to work because it would hit a nil pointer exception for forget_me!. current_user can't be used within with forget_me! method since session[:user_id] is no longer set due to the call to reset_session.
