### PR TITLE
change Twitter API endpoint url to v1.1

### DIFF
--- a/lib/sorcery/controller/submodules/external/providers/twitter.rb
+++ b/lib/sorcery/controller/submodules/external/providers/twitter.rb
@@ -48,7 +48,7 @@ module Sorcery
                 
                 def init
                   @site           = "https://api.twitter.com"
-                  @user_info_path = "/1/account/verify_credentials.json"
+                  @user_info_path = "/1.1/account/verify_credentials.json"
                   @user_info_mapping = {}
                 end
                 


### PR DESCRIPTION
Can not use the Twitter API Version 1 from 2013/6/11.
So, I was changed to 1.1 the endpoint URL
