### PR TITLE
Changed sqlite3 gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :development do
   gem "rspec", "~> 2.5.0"
   gem 'rspec-rails', "~> 2.5.0"
   #gem 'ruby-debug19'
-  gem 'sqlite3-ruby', :require => 'sqlite3'
+  gem 'sqlite3'
   gem "yard", "~> 0.6.0"
   gem "bundler", ">= 1.1.0"
   gem "jeweler", "~> 1.8.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.5)
+    sqlite3 (1.3.7)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
     thor (0.14.6)


### PR DESCRIPTION
The sqlite3 gem throws deprecated warnings upon installing sqlite3-ruby.   

'sqlite3' is now the preferred name for the gem.
