### PR TITLE
Use change method in migrations instead of self.up and self.down

### DIFF
--- a/lib/generators/sorcery/templates/migration/activity_logging.rb
+++ b/lib/generators/sorcery/templates/migration/activity_logging.rb
@@ -1,19 +1,10 @@
 class SorceryActivityLogging < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= model_class_name.tableize %>, :last_login_at,     :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :last_logout_at,    :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :last_activity_at,  :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :last_login_from_ip_address, :string, :default => nil
-    
-    add_index :<%= model_class_name.tableize %>, [:last_logout_at, :last_activity_at]
-  end
 
-  def self.down
-    remove_index :<%= model_class_name.tableize %>, [:last_logout_at, :last_activity_at]
-    
-    remove_column :<%= model_class_name.tableize %>, :last_login_from_ip_address
-    remove_column :<%= model_class_name.tableize %>, :last_activity_at
-    remove_column :<%= model_class_name.tableize %>, :last_logout_at
-    remove_column :<%= model_class_name.tableize %>, :last_login_at
+    add_index :<%= model_class_name.tableize %>, [:last_logout_at, :last_activity_at]
   end
 end

--- a/lib/generators/sorcery/templates/migration/brute_force_protection.rb
+++ b/lib/generators/sorcery/templates/migration/brute_force_protection.rb
@@ -1,13 +1,7 @@
 class SorceryBruteForceProtection < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= model_class_name.tableize %>, :failed_logins_count, :integer, :default => 0
     add_column :<%= model_class_name.tableize %>, :lock_expires_at, :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :unlock_token, :string, :default => nil
-  end
-
-  def self.down
-    remove_column :<%= model_class_name.tableize %>, :lock_expires_at
-    remove_column :<%= model_class_name.tableize %>, :failed_logins_count
-    remove_column :<%= model_class_name.tableize %>, :unlock_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -1,5 +1,5 @@
 class SorceryCore < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :<%= model_class_name.tableize %> do |t|
       t.string :username,         :null => false  # if you use another field as a username, for example email, you can safely remove this field.
       t.string :email,            :default => nil # if you use this field as a username, you might want to make it :null => false.
@@ -8,9 +8,5 @@ class SorceryCore < ActiveRecord::Migration
 
       t.timestamps
     end
-  end
-
-  def self.down
-    drop_table :<%= model_class_name.tableize %>
   end
 end

--- a/lib/generators/sorcery/templates/migration/external.rb
+++ b/lib/generators/sorcery/templates/migration/external.rb
@@ -1,14 +1,10 @@
 class SorceryExternal < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :authentications do |t|
       t.integer :<%= model_class_name.tableize.singularize %>_id, :null => false
       t.string :provider, :uid, :null => false
 
       t.timestamps
     end
-  end
-
-  def self.down
-    drop_table :authentications
   end
 end

--- a/lib/generators/sorcery/templates/migration/remember_me.rb
+++ b/lib/generators/sorcery/templates/migration/remember_me.rb
@@ -1,15 +1,8 @@
 class SorceryRememberMe < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= model_class_name.tableize %>, :remember_me_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :remember_me_token_expires_at, :datetime, :default => nil
-    
-    add_index :<%= model_class_name.tableize %>, :remember_me_token
-  end
 
-  def self.down
-    remove_index :<%= model_class_name.tableize %>, :remember_me_token
-    
-    remove_column :<%= model_class_name.tableize %>, :remember_me_token_expires_at
-    remove_column :<%= model_class_name.tableize %>, :remember_me_token
+    add_index :<%= model_class_name.tableize %>, :remember_me_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/reset_password.rb
+++ b/lib/generators/sorcery/templates/migration/reset_password.rb
@@ -1,17 +1,9 @@
 class SorceryResetPassword < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= model_class_name.tableize %>, :reset_password_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :reset_password_token_expires_at, :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :reset_password_email_sent_at, :datetime, :default => nil
-    
-    add_index :<%= model_class_name.tableize %>, :reset_password_token
-  end
 
-  def self.down
-    remove_index :<%= model_class_name.tableize %>, :reset_password_token
-    
-    remove_column :<%= model_class_name.tableize %>, :reset_password_email_sent_at
-    remove_column :<%= model_class_name.tableize %>, :reset_password_token_expires_at
-    remove_column :<%= model_class_name.tableize %>, :reset_password_token
+    add_index :<%= model_class_name.tableize %>, :reset_password_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/user_activation.rb
+++ b/lib/generators/sorcery/templates/migration/user_activation.rb
@@ -1,17 +1,9 @@
 class SorceryUserActivation < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= model_class_name.tableize %>, :activation_state, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :activation_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :activation_token_expires_at, :datetime, :default => nil
-    
-    add_index :<%= model_class_name.tableize %>, :activation_token
-  end
 
-  def self.down
-    remove_index :<%= model_class_name.tableize %>, :activation_token
-    
-    remove_column :<%= model_class_name.tableize %>, :activation_token_expires_at
-    remove_column :<%= model_class_name.tableize %>, :activation_token
-    remove_column :<%= model_class_name.tableize %>, :activation_state
+    add_index :<%= model_class_name.tableize %>, :activation_token
   end
 end


### PR DESCRIPTION
In migration files there is no need to declare up and down methods. With change method rails can guess what is the inverse operation.
