### PR TITLE
remember_me submodule raise error in forget_me! method

### DIFF
--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -31,7 +31,7 @@ module Sorcery
 
           # Clears the cookie and clears the token from the db.
           def forget_me!
-            @current_user.forget_me!
+            current_user.forget_me!
             cookies.delete(:remember_me_token, :domain => Config.cookie_domain)
           end
 


### PR DESCRIPTION
We should call current_user instead of @current_user, because if we don't fill @current_user before it is only nil.
