### PR TITLE
Separate reset generation from mailer

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -9,14 +9,14 @@ module Sorcery
       # he will be able to reset his password via a form.
       #
       # When using this submodule, supplying a mailer is mandatory.
-      module ResetPassword       
+      module ResetPassword
         def self.included(base)
           base.sorcery_config.class_eval do
             attr_accessor :reset_password_token_attribute_name,              # reset password code attribute name.
                           :reset_password_token_expires_at_attribute_name,   # expires at attribute name.
                           :reset_password_email_sent_at_attribute_name,      # when was email sent, used for hammering
                                                                              # protection.
-                                                                             
+
                           :reset_password_mailer,                            # mailer class. Needed.
 
                           :reset_password_mailer_disabled,                   # when true sorcery will not automatically
@@ -25,15 +25,15 @@ module Sorcery
 
                           :reset_password_email_method_name,                 # reset password email method on your
                                                                              # mailer class.
-                                                                             
+
                           :reset_password_expiration_period,                 # how many seconds before the reset request
                                                                              # expires. nil for never expires.
-                                                                             
+
                           :reset_password_time_between_emails                # hammering protection, how long to wait
                                                                              # before allowing another email to be sent.
 
           end
-          
+
           base.sorcery_config.instance_eval do
             @defaults.merge!(:@reset_password_token_attribute_name            => :reset_password_token,
                              :@reset_password_token_expires_at_attribute_name => :reset_password_token_expires_at,
@@ -58,7 +58,7 @@ module Sorcery
           base.send(:include, InstanceMethods)
 
         end
-        
+
         module ClassMethods
           # Find user by token, also checks for expiration.
           # Returns the user if token found and is valid.
@@ -67,9 +67,9 @@ module Sorcery
             token_expiration_date_attr = @sorcery_config.reset_password_token_expires_at_attribute_name
             load_from_token(token, token_attr_name, token_expiration_date_attr)
           end
-          
+
           protected
-          
+
           # This submodule requires the developer to define his own mailer class to be used by it
           # when reset_password_mailer_disabled is false
           def validate_mailer_defined
@@ -82,29 +82,26 @@ module Sorcery
             field sorcery_config.reset_password_token_expires_at_attribute_name,  :type => Time
             field sorcery_config.reset_password_email_sent_at_attribute_name,     :type => Time
           end
-          
+
           def define_reset_password_mongo_mapper_fields
             key sorcery_config.reset_password_token_attribute_name, String
             key sorcery_config.reset_password_token_expires_at_attribute_name, Time
             key sorcery_config.reset_password_email_sent_at_attribute_name, Time
           end
         end
-        
+
         module InstanceMethods
           # generates a reset code with expiration and sends an email to the user.
           def deliver_reset_password_instructions!
             config = sorcery_config
             # hammering protection
             return false if config.reset_password_time_between_emails && self.send(config.reset_password_email_sent_at_attribute_name) && self.send(config.reset_password_email_sent_at_attribute_name) > config.reset_password_time_between_emails.ago.utc
-            attributes = {config.reset_password_token_attribute_name => TemporaryToken.generate_random_token,
-                          config.reset_password_email_sent_at_attribute_name => Time.now.in_time_zone}
-            attributes[config.reset_password_token_expires_at_attribute_name] = Time.now.in_time_zone + config.reset_password_expiration_period if config.reset_password_expiration_period
             self.class.transaction do
-              self.update_many_attributes(attributes)
+              generate_reset!
               send_reset_password_email! unless sorcery_config.reset_password_mailer_disabled
             end
           end
-          
+
           # Clears token and tries to update the new password for the user.
           def change_password!(new_password)
             clear_reset_password_token
@@ -112,8 +109,18 @@ module Sorcery
             save
           end
 
+          # Generates a reset code with expiration.
+          def generate_reset!
+            config = sorcery_config
+
+            attributes = {config.reset_password_token_attribute_name => TemporaryToken.generate_random_token,
+                          config.reset_password_email_sent_at_attribute_name => Time.now.in_time_zone}
+            attributes[config.reset_password_token_expires_at_attribute_name] = Time.now.in_time_zone + config.reset_password_expiration_period if config.reset_password_expiration_period
+            self.update_many_attributes(attributes)
+          end
+
           protected
-          
+
           def send_reset_password_email!
             generic_send_email(:reset_password_email_method_name, :reset_password_mailer)
           end
@@ -125,7 +132,7 @@ module Sorcery
             self.send(:"#{config.reset_password_token_expires_at_attribute_name}=", nil) if config.reset_password_expiration_period
           end
         end
-        
+
       end
     end
   end


### PR DESCRIPTION
This is more of a proof-of-concept, but doesn't seem to break any specs. It separates generating a password reset from the action of sending an email. Aside from separating concerns, I think it's a win in a few other cases as well (e.g. can just generate the reset for purposes of a unit test).
