### PR TITLE
Add integration testing support to login_user test helpers

### DIFF
--- a/lib/sorcery.rb
+++ b/lib/sorcery.rb
@@ -42,10 +42,14 @@ module Sorcery
   end
   autoload :TestHelpers, 'sorcery/test_helpers'
   module TestHelpers
-    autoload :Rails, 'sorcery/test_helpers/rails'
     autoload :Internal, 'sorcery/test_helpers/internal'
     module Internal
       autoload :Rails, 'sorcery/test_helpers/internal/rails'
+    end
+    autoload :Rails, 'sorcery/test_helpers/rails'
+    module Rails
+      autoload :Controller, 'sorcery/test_helpers/rails/controller'
+      autoload :Integration, 'sorcery/test_helpers/rails/integration'
     end
 
   end

--- a/lib/sorcery/test_helpers/internal/rails.rb
+++ b/lib/sorcery/test_helpers/internal/rails.rb
@@ -2,7 +2,7 @@ module Sorcery
   module TestHelpers
     module Internal
       module Rails
-        include ::Sorcery::TestHelpers::Rails
+        include ::Sorcery::TestHelpers::Rails::Controller
 
         SUBMODUELS_AUTO_ADDED_CONTROLLER_FILTERS = [
           :register_last_activity_time_to_db,

--- a/lib/sorcery/test_helpers/rails.rb
+++ b/lib/sorcery/test_helpers/rails.rb
@@ -1,16 +1,7 @@
 module Sorcery
   module TestHelpers
     module Rails
-      # logins a user and calls all callbacks
-      def login_user(user = nil)
-        user ||= @user
-        @controller.send(:auto_login, user)
-        @controller.send(:after_login!, user, [user.send(user.sorcery_config.username_attribute_names.first), 'secret'])
-      end
 
-      def logout_user
-        @controller.send(:logout)
-      end
     end
   end
 end

--- a/lib/sorcery/test_helpers/rails/controller.rb
+++ b/lib/sorcery/test_helpers/rails/controller.rb
@@ -1,0 +1,17 @@
+module Sorcery
+  module TestHelpers
+    module Rails
+      module Controller 
+        def login_user(user = nil, test_context = {})
+          user ||= @user
+          @controller.send(:auto_login, user)
+          @controller.send(:after_login!, user, [user.send(user.sorcery_config.username_attribute_names.first), 'secret'])
+        end
+
+        def logout_user
+          @controller.send(:logout)
+        end
+      end
+    end
+  end
+end

--- a/lib/sorcery/test_helpers/rails/integration.rb
+++ b/lib/sorcery/test_helpers/rails/integration.rb
@@ -1,0 +1,24 @@
+module Sorcery
+  module TestHelpers
+    module Rails
+      module Integration
+        
+        #Accepts arguments for user to login and route to use 
+        #Defaults - @user and 'sessions_url'
+        def login_user(user = nil, route = nil)
+          user ||= @user
+          username = user.send(user.sorcery_config.username_attribute_names.first)
+          route ||= sessions_url
+          page.driver.post(route, { username: username, password: 'secret' })
+        end
+
+        #Accepts route argument
+        #Default - 'logout_url'
+        def logout_user(route = nil)
+          route ||= logout_url
+          page.driver.get(route)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backward-compatible changes to the `login_user` and `logout_user` helpers that allow the test to simulate the relevant http requests with Capybara for integration testing purposes (where the current methods don't work). Hopefully spares people the need to find and then copy/paste a solution from the wiki or issue #33.
