### PR TITLE
Use find_by_id instead of find when looking for user

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -126,11 +126,7 @@ module Sorcery
       end
 
       def login_from_session
-        @current_user = (user_class.find(session[:user_id]) if session[:user_id]) || nil
-      rescue => exception
-        return nil if defined?(Mongoid) and exception.is_a?(Mongoid::Errors::DocumentNotFound)
-        return nil if defined?(ActiveRecord) and exception.is_a?(ActiveRecord::RecordNotFound)
-        raise exception
+        @current_user = (user_class.find_by_id(session[:user_id]) if session[:user_id]) || nil
       end
 
       def after_login!(user, credentials = [])


### PR DESCRIPTION
Related issue: https://github.com/NoamB/sorcery/issues/376

So I've changed this method, but it actually does not change library behaviour - Sorcery should not crash on `login_from_session` because it rescues `NotFound` errors. Anyway, this way method is simpler, and when we merge https://github.com/NoamB/sorcery/pull/509 I'll be able to simplify it even more (no need to return false then)
