### PR TITLE
fix datamapper specs for password_confirmation

### DIFF
--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -194,6 +194,9 @@ shared_examples_for "rails_3_core_model" do
     describe "when user has password_confirmation_defined" do
       before(:all) do
         User.class_eval { attr_accessor :password_confirmation }
+        if defined?(DataMapper)
+          DataMapper.finalize
+        end
       end
 
       after(:all) do


### PR DESCRIPTION
Some time ago I added specs for password_confirmation, but I haven't noticed they didn't work for DataMapper. I looked into the problem and fixed the specs.
