### PR TITLE
add ruby 2.1.0 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
 
 services: mongodb
 


### PR DESCRIPTION
I use Ruby 2.1.0 while developing Sorcery and tests pass with no problems, so we should officially support this version.
