### PR TITLE
Added Jira as external provider

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -140,6 +140,18 @@ Rails.application.config.sorcery.configure do |config|
   # config.liveid.callback_url = "http://mydomain.com:3000/oauth/callback?provider=liveid"
   # config.liveid.user_info_mapping = {:username => "name"}
 
+  # For information about JIRA API:
+  # https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+OAuth+authentication
+  # to obtain the consumer key and the public key you can use the jira-ruby gem https://github.com/sumoheavy/jira-ruby
+  # or run openssl req -x509 -nodes -newkey rsa:1024 -sha1 -keyout rsakey.pem -out rsacert.pem to obtain the public key
+  # Make sure you have configured the application link properly
+
+  # config.jira.key = "1234567"
+  # config.jira.secret = "jiraTest"
+  # config.jira.site = "http://localhost:2990/jira/plugins/servlet/oauth"
+  # config.jira.signature_method =  "RSA-SHA1"
+  # config.jira.private_key_file = "rsakey.pem"
+
 
   # --- user config ---
   config.user_config do |user|

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -16,6 +16,7 @@ module Sorcery
           require 'sorcery/providers/xing'
           require 'sorcery/providers/github'
           require 'sorcery/providers/google'
+          require 'sorcery/providers/jira'
 
           Config.module_eval do
             class << self

--- a/lib/sorcery/providers/jira.rb
+++ b/lib/sorcery/providers/jira.rb
@@ -1,0 +1,77 @@
+module Sorcery
+  module Providers
+    # This class adds support for OAuth with Jira
+    #
+    #   config.jira.key = <key>
+    #   config.jira.secret = <secret>
+    #   ...
+    #
+    class Jira < Base
+
+      include Protocols::Oauth
+
+      attr_accessor :access_token_path, :authorize_path, :request_token_path,
+                    :user_info_path, :site, :signature_method, :private_key_file, :callback_url
+
+
+      def initialize
+        @configuration = {
+            authorize_path: '/authorize',
+            request_token_path: '/request-token',
+            access_token_path: '/access-token'
+        }
+        @user_info_path = '/users/me'
+      end
+
+      # Override included get_consumer method to provide authorize_path
+      #read extra configurations
+      def get_consumer
+        @configuration = @configuration.merge({
+            site: site,
+            signature_method: signature_method,
+            consumer_key: key,
+            private_key_file: private_key_file
+        })
+        ::OAuth::Consumer.new(@key, @secret, @configuration)
+      end
+
+      def get_user_hash(access_token)
+        response = access_token.get(user_info_path)
+
+        {}.tap do |h|
+          h[:user_info] = JSON.parse(response.body)['users'].first
+          h[:uid] = user_hash[:user_info]['id'].to_s
+        end
+      end
+
+      # calculates and returns the url to which the user should be redirected,
+      # to get authenticated at the external provider's site.
+      def login_url(params, session)
+        req_token = get_request_token
+        session[:request_token]         = req_token.token
+        session[:request_token_secret]  = req_token.secret
+
+        #it was like that -> redirect_to authorize_url({ request_token: req_token.token, request_token_secret: req_token.secret })
+        #for some reason Jira does not need these parameters
+
+        get_request_token(
+          session[:request_token],
+          session[:request_token_secret]
+        ).authorize_url
+      end
+
+      # tries to login the user from access token
+      def process_callback(params, session)
+        args = {
+          oauth_verifier:       params[:oauth_verifier],
+          request_token:        session[:request_token],
+          request_token_secret: session[:request_token_secret]
+        }
+
+        args.merge!({ code: params[:code] }) if params[:code]
+        get_access_token(args)
+      end
+
+    end
+  end
+end

--- a/spec/active_record/controller_oauth_spec.rb
+++ b/spec/active_record/controller_oauth_spec.rb
@@ -27,10 +27,17 @@ describe SorceryController, :active_record => true do
     User.reset_column_information
 
     sorcery_reload!([:external])
-    sorcery_controller_property_set(:external_providers, [:twitter])
+    sorcery_controller_property_set(:external_providers, [:twitter, :jira])
     sorcery_controller_external_property_set(:twitter, :key, "eYVNBjBDi33aa9GkA3w")
     sorcery_controller_external_property_set(:twitter, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
     sorcery_controller_external_property_set(:twitter, :callback_url, "http://blabla.com")
+
+    sorcery_controller_external_property_set(:jira, :key, "7810b8e317ebdc81601c72f8daecc0f1")
+    sorcery_controller_external_property_set(:jira, :secret, "MyAppUsingJira")
+    sorcery_controller_external_property_set(:jira, :site, "http://jira.mycompany.com/plugins/servlet/oauth")
+    sorcery_controller_external_property_set(:jira, :signature_method, "RSA-SHA1")
+    sorcery_controller_external_property_set(:jira, :private_key_file, "myrsakey.pem")
+    sorcery_controller_external_property_set(:jira, :callback_url, "http://myappusingjira.com/home")
   end
 
   after(:all) do
@@ -92,6 +99,14 @@ describe SorceryController, :active_record => true do
       get :test_return_to_with_external, {}, :return_to_url => "fuu"
       expect(response).to redirect_to("fuu")
       expect(flash[:notice]).to eq "Success!"
+    end
+
+    context "when jira" do
+      it "user logins successfully" do
+        get :login_at_test_jira
+        expect(session[:request_token]).not_to be_nil
+        expect(response).to be_a_redirect
+      end
     end
 
   end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -98,6 +98,10 @@ class SorceryController < ActionController::Base
     login_at(:liveid)
   end
 
+  def login_at_test_jira
+    login_at(:jira)
+  end
+
   def login_at_test_vk
     login_at(:vk)
   end
@@ -156,8 +160,24 @@ class SorceryController < ActionController::Base
     end
   end
 
+  def test_login_from_jira
+    if @user = login_from(:jira)
+      redirect_to 'bla', notice: 'Success!'
+    else
+      redirect_to 'blu', alert: 'Failed!'
+    end
+  end
+
   def test_return_to_with_external_twitter
     if @user = login_from(:twitter)
+      redirect_back_or_to 'bla', notice: 'Success!'
+    else
+      redirect_to 'blu', alert: 'Failed!'
+    end
+  end
+
+  def test_return_to_with_external_jira
+    if @user = login_from(:jira)
       redirect_back_or_to 'bla', notice: 'Success!'
     else
       redirect_to 'blu', alert: 'Failed!'

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -22,6 +22,7 @@ AppRoot::Application.routes.draw do
     get :test_login_from_google
     get :test_login_from_liveid
     get :test_login_from_vk
+    get :test_login_from_jira
     get :login_at_test
     get :login_at_test_twitter
     get :login_at_test_facebook
@@ -29,6 +30,7 @@ AppRoot::Application.routes.draw do
     get :login_at_test_google
     get :login_at_test_liveid
     get :login_at_test_vk
+    get :login_at_test_jira
     get :test_return_to_with_external
     get :test_return_to_with_external_twitter
     get :test_return_to_with_external_facebook
@@ -36,6 +38,7 @@ AppRoot::Application.routes.draw do
     get :test_return_to_with_external_google
     get :test_return_to_with_external_liveid
     get :test_return_to_with_external_vk
+    get :test_return_to_with_external_jira
     get :test_http_basic_auth
     get :some_action_making_a_non_persisted_change_to_the_user
     post :test_login_with_remember


### PR DESCRIPTION
I created the option to use JIRA as external provider, while working for Meltwater. We use JIRA and sorcery internally. JIRA is a proprietary issue tracking product, developed by Atlassian.(http://www.atlassian.com/JIRA)

There are some configurations for JIRA that are different from other providers because JIRA is not a website like twitter that you can just go and create your account, most of companies has a domain like jira.company-name.com running somewhere. So to test I created this application: https://github.com/camilasan/jira-login-example

I tried to write tests, but it will only pass if you have JIRA running. 

I hope this is helpful. Let me know if you have any questions.
