### PR TITLE
support scopes for VK oauth provider

### DIFF
--- a/lib/sorcery/providers/vk.rb
+++ b/lib/sorcery/providers/vk.rb
@@ -10,8 +10,7 @@ module Sorcery
 
       include Protocols::Oauth2
 
-      attr_accessor :auth_path, :token_path, :user_info_url
-      attr_accessor :scope
+      attr_accessor :auth_path, :token_path, :user_info_url, :scope
 
       def initialize
         super


### PR DESCRIPTION
Now you can write

``` ruby
config.vk.scope = 'photos,offline,groups'
```

and such in your `config/initializers/sorcery.rb` file
