### PR TITLE
Fix session timeout to work with Rails cookie store

### DIFF
--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -38,6 +38,7 @@ module Sorcery
           def validate_session
             session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
             if session_to_use && (Time.now.in_time_zone - session_to_use > Config.session_timeout)
+            if session_to_use && (Time.now.in_time_zone - session_to_use.to_time > Config.session_timeout)
               reset_sorcery_session
               @current_user = nil
             else

--- a/spec/active_record/controller_session_timeout_spec.rb
+++ b/spec/active_record/controller_session_timeout_spec.rb
@@ -29,6 +29,13 @@ describe SorceryController do
       response.should be_a_redirect
     end
 
+    it "should work if the session is stored as a string or a Time" do
+      session[:login_time] = Time.now.to_s
+      get :test_login, :email => 'bla@bla.com', :password => 'secret'
+      session[:user_id].should_not be_nil
+      response.should be_a_success
+    end
+
     context "with 'session_timeout_from_last_action'" do
       it "should not logout if there was activity" do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)


### PR DESCRIPTION
Rails cookie-based default session store represents times as Strings, which must be converted to times before comparison.

The current session timeout code causes an error with a blank/new Rails 4 app.
