### PR TITLE
Use more general Ruby 2.1 version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.1
 
 services: mongodb
 
@@ -29,7 +29,7 @@ matrix:
       gemfile: Gemfile.rails4
       env: "SORCERY_ORM=datamapper"
 
-    - rvm: 2.1.2
+    - rvm: 2.1
       gemfile: Gemfile.rails4
       env: "SORCERY_ORM=datamapper"
 
@@ -42,7 +42,7 @@ matrix:
       gemfile: gemfiles/mongoid-rails41.gemfile
       env: "SORCERY_ORM=mongoid"
 
-    - rvm: 2.1.2
+    - rvm: 2.1
       gemfile: gemfiles/mongoid-rails41.gemfile
       env: "SORCERY_ORM=mongoid"
 
@@ -54,7 +54,7 @@ matrix:
       gemfile: gemfiles/mongo_mapper-rails41.gemfile
       env: "SORCERY_ORM=mongo_mapper"
 
-    - rvm: 2.1.2
+    - rvm: 2.1
       gemfile: gemfiles/mongo_mapper-rails41.gemfile
       env: "SORCERY_ORM=mongo_mapper"
 
@@ -66,6 +66,6 @@ matrix:
       gemfile: gemfiles/active_record-rails41.gemfile
       env: "SORCERY_ORM=active_record"
 
-    - rvm: 2.1.2
+    - rvm: 2.1
       gemfile: gemfiles/active_record-rails41.gemfile
       env: "SORCERY_ORM=active_record"


### PR DESCRIPTION
Since Ruby 2.1 versioning changed, patch versions are not going to be used
anymore, so Ruby 2.1.2 is what used to be Ruby 2.0.0-pxxx
Therefore Travis allows more general ruby version now, and always will use the
newest tiny version available
