### PR TITLE
VK email and full_name fields fix

### DIFF
--- a/lib/sorcery/providers/vk.rb
+++ b/lib/sorcery/providers/vk.rb
@@ -35,8 +35,9 @@ module Sorcery
         response = access_token.get(user_info_url, params: params)
         if user_hash[:user_info] = JSON.parse(response.body)
           user_hash[:user_info] = user_hash[:user_info]['response'][0]
-          user_hash[:user_info]['full_name'] = [user_hash[:user_info]['first_name'], user_hash[:user_info]['last_name']].join
+          user_hash[:user_info]['full_name'] = [user_hash[:user_info]['first_name'], user_hash[:user_info]['last_name']].join ' '
           user_hash[:uid] = user_hash[:user_info]['uid']
+          user_hash[:user_info]['email'] = access_token.params['email']
         end
         user_hash
       end


### PR DESCRIPTION
This commit fixes two errors: 
- Full name is joined incorretly: it gave `AndrewShaydurov` instead of `Andrew Shaydurov` (without a space between name and surname)
- For some unknown reason VK does not return proper email field for request even when scope and fields are set to `email`. But email is accessible from access_token response.
