### PR TITLE
Fix RSpec configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ Important notes while upgrading:
     you need to change the way you include them to following code:
 
         RSpec.configure do |config|
-          config.include Sorcery::TestHelpers::Rails::Controller, type: [:controller]
-          config.include Sorcery::TestHelpers::Rails::Integration, type: [:feature]
+          config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
+          config.include Sorcery::TestHelpers::Rails::Integration, type: :feature
         end
 
 *   If are upgrading to **0.8.2** and use activity_logging feature with


### PR DESCRIPTION
In order to be properly loaded, the provided type cannot be an array.
