### PR TITLE
Move defining fields to adapters

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -31,13 +31,13 @@ module Sorcery
     def define_base_fields
       self.class_eval do
         sorcery_config.username_attribute_names.each do |username|
-          define_field username, String, length: 255
+          define_sorcery_field username, String, length: 255
         end
         unless sorcery_config.username_attribute_names.include?(sorcery_config.email_attribute_name)
-          define_field sorcery_config.email_attribute_name, String, length: 255
+          define_sorcery_field sorcery_config.email_attribute_name, String, length: 255
         end
-        define_field sorcery_config.crypted_password_attribute_name, String, length: 255
-        define_field sorcery_config.salt_attribute_name, String, length: 255
+        define_sorcery_field sorcery_config.crypted_password_attribute_name, String, length: 255
+        define_sorcery_field sorcery_config.salt_attribute_name, String, length: 255
       end
 
     end
@@ -60,11 +60,11 @@ module Sorcery
 
     # add virtual password accessor and ORM callbacks.
     def init_orm_hooks!
-      define_callback :before, :validation, :encrypt_password, if: Proc.new {|record|
+      define_sorcery_callback :before, :validation, :encrypt_password, if: Proc.new {|record|
         record.send(sorcery_config.password_attribute_name).present?
       }
 
-      define_callback :after, :save, :clear_virtual_password, if: Proc.new {|record|
+      define_sorcery_callback :after, :save, :clear_virtual_password, if: Proc.new {|record|
         record.send(sorcery_config.password_attribute_name).present?
       }
 

--- a/lib/sorcery/model/adapters/active_record.rb
+++ b/lib/sorcery/model/adapters/active_record.rb
@@ -27,11 +27,11 @@ module Sorcery
         end
         
         module ClassMethods
-          def define_field(name, type, options={})
+          def define_sorcery_field(name, type, options={})
             # AR fields are defined through migrations, only validator here
           end
 
-          def define_callback(time, event, method_name, options={})
+          def define_sorcery_callback(time, event, method_name, options={})
             send "#{time}_#{event}", method_name, options.slice(:if)
           end
 

--- a/lib/sorcery/model/adapters/datamapper.rb
+++ b/lib/sorcery/model/adapters/datamapper.rb
@@ -36,7 +36,7 @@ module Sorcery
         end
 
         module ClassMethods
-          def define_field(name, type, options={})
+          def define_sorcery_field(name, type, options={})
             property name, type, options.slice(:length, :default)
 
             # Workaround local timezone retrieval problem NOTE dm-core issue #193
@@ -49,7 +49,7 @@ module Sorcery
             end
           end
 
-          def define_callback(time, event, method_name, options={})
+          def define_sorcery_callback(time, event, method_name, options={})
             event = :valid? if event == :validation
             condition = options[:if]
 

--- a/lib/sorcery/model/adapters/mongo_mapper.rb
+++ b/lib/sorcery/model/adapters/mongo_mapper.rb
@@ -25,11 +25,11 @@ module Sorcery
         end
 
         module ClassMethods
-          def define_field(name, type, options={})
+          def define_sorcery_field(name, type, options={})
             key name, type, options.slice(:default)
           end
 
-          def define_callback(time, event, method_name, options={})
+          def define_sorcery_callback(time, event, method_name, options={})
             send "#{time}_#{event}", method_name, options.slice(:if)
           end
 

--- a/lib/sorcery/model/adapters/mongoid.rb
+++ b/lib/sorcery/model/adapters/mongoid.rb
@@ -26,11 +26,11 @@ module Sorcery
         end
 
         module ClassMethods
-          def define_field(name, type, options={})
+          def define_sorcery_field(name, type, options={})
             field name, options.slice(:default).merge(type: type)
           end
 
-          def define_callback(time, event, method_name, options={})
+          def define_sorcery_callback(time, event, method_name, options={})
             send "#{time}_#{event}", method_name, options.slice(:if)
           end
 

--- a/lib/sorcery/model/submodules/activity_logging.rb
+++ b/lib/sorcery/model/submodules/activity_logging.rb
@@ -46,10 +46,10 @@ module Sorcery
 
           protected
           def define_activity_logging_fields
-            define_field sorcery_config.last_login_at_attribute_name,    Time
-            define_field sorcery_config.last_logout_at_attribute_name,   Time
-            define_field sorcery_config.last_activity_at_attribute_name, Time
-            define_field sorcery_config.last_login_from_ip_address_name, String
+            define_sorcery_field sorcery_config.last_login_at_attribute_name,    Time
+            define_sorcery_field sorcery_config.last_logout_at_attribute_name,   Time
+            define_sorcery_field sorcery_config.last_activity_at_attribute_name, Time
+            define_sorcery_field sorcery_config.last_login_from_ip_address_name, String
           end
         end
       end

--- a/lib/sorcery/model/submodules/brute_force_protection.rb
+++ b/lib/sorcery/model/submodules/brute_force_protection.rb
@@ -50,9 +50,9 @@ module Sorcery
           protected
 
           def define_brute_force_protection_fields
-            define_field sorcery_config.failed_logins_count_attribute_name, Integer, :default => 0
-            define_field sorcery_config.lock_expires_at_attribute_name, Time
-            define_field sorcery_config.unlock_token_attribute_name, String
+            define_sorcery_field sorcery_config.failed_logins_count_attribute_name, Integer, :default => 0
+            define_sorcery_field sorcery_config.lock_expires_at_attribute_name, Time
+            define_sorcery_field sorcery_config.unlock_token_attribute_name, String
           end
         end
 

--- a/lib/sorcery/model/submodules/remember_me.rb
+++ b/lib/sorcery/model/submodules/remember_me.rb
@@ -31,8 +31,8 @@ module Sorcery
           protected
 
           def define_remember_me_fields
-            define_field sorcery_config.remember_me_token_attribute_name, String
-            define_field sorcery_config.remember_me_token_expires_at_attribute_name, Time
+            define_sorcery_field sorcery_config.remember_me_token_attribute_name, String
+            define_sorcery_field sorcery_config.remember_me_token_expires_at_attribute_name, Time
           end
 
         end

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -75,9 +75,9 @@ module Sorcery
           end
 
           def define_reset_password_fields
-            define_field sorcery_config.reset_password_token_attribute_name, String
-            define_field sorcery_config.reset_password_token_expires_at_attribute_name, Time
-            define_field sorcery_config.reset_password_email_sent_at_attribute_name, Time
+            define_sorcery_field sorcery_config.reset_password_token_attribute_name, String
+            define_sorcery_field sorcery_config.reset_password_token_expires_at_attribute_name, Time
+            define_sorcery_field sorcery_config.reset_password_email_sent_at_attribute_name, Time
           end
 
         end

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -52,9 +52,9 @@ module Sorcery
 
           base.class_eval do
             # don't setup activation if no password supplied - this user is created automatically
-            define_callback :before, :create, :setup_activation, :if => Proc.new { |user| user.send(sorcery_config.password_attribute_name).present? }
+            define_sorcery_callback :before, :create, :setup_activation, :if => Proc.new { |user| user.send(sorcery_config.password_attribute_name).present? }
             # don't send activation needed email if no crypted password created - this user is external (OAuth etc.)
-            define_callback :after, :create, :send_activation_needed_email!, :if => :send_activation_needed_email?
+            define_sorcery_callback :after, :create, :send_activation_needed_email!, :if => :send_activation_needed_email?
           end
 
           base.sorcery_config.after_config << :validate_mailer_defined
@@ -87,9 +87,9 @@ module Sorcery
 
           def define_user_activation_fields
             self.class_eval do
-              define_field sorcery_config.activation_state_attribute_name, String
-              define_field sorcery_config.activation_token_attribute_name, String
-              define_field sorcery_config.activation_token_expires_at_attribute_name, Time
+              define_sorcery_field sorcery_config.activation_state_attribute_name, String
+              define_sorcery_field sorcery_config.activation_token_attribute_name, String
+              define_sorcery_field sorcery_config.activation_token_expires_at_attribute_name, Time
             end
           end
         end


### PR DESCRIPTION
Currently in every single submodule that requires additional fields in model,
we've got a conditional block for each ORM. To reduce code duplication,
a `define_field` method was added to each of ORM adapters. Now we can run it no
matter what ORM is used, and adapter will handle it.

This is the first step to extracting adapters. Next one will be to move defining callbacks to adapters.

cc @kirs

_Update_

Ok, I've already moved defining callbacks, too, and I've added it to this PR.
