### PR TITLE
Replace `migrations` generator option with `only-submodules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This will generate the core migration file, the initializer and change the
 model class (in the initializer and migration files) to the class 'Person'
 (and its pluralized version, 'people')
 
-    rails generate sorcery:install http_basic_auth external remember_me --migrations
+    rails generate sorcery:install http_basic_auth external remember_me --only-submodules
 
 This will generate only the migration files for the specified submodules and
 will add them to the initializer file.

--- a/lib/generators/sorcery/USAGE
+++ b/lib/generators/sorcery/USAGE
@@ -16,7 +16,7 @@ Examples:
     This will generate the core migration file, the initializer and change the model class
     (in the initializer and migration files) to the class 'Person' (and it's pluralized version, 'people')
 
-  rails generate sorcery:install http_basic_auth external remember_me --migrations
+  rails generate sorcery:install http_basic_auth external remember_me --only-submodules
 
     This will generate only the migration files for the specified submodules and will
     add them to the initializer file.


### PR DESCRIPTION
Generator has an option `--migrations` that actually does not do what its name
says. It also changes user model and initializer. The real change it does is
that if it's provided, no core files are copied (user model is not generated,
core migrations are not copied).

Therefore the proper name for this option is `--only-submodules`.
The previous option was deprecated and should be removed in v0.9.0.
