### PR TITLE
Move ActivityLogging DM compatibility check to adapter

### DIFF
--- a/lib/sorcery/model/adapters/data_mapper.rb
+++ b/lib/sorcery/model/adapters/data_mapper.rb
@@ -3,8 +3,17 @@ module Sorcery
     module Adapters
       module DataMapper
         def self.included(klass)
+          verify_sorcery_submodules_compatibility
           klass.extend ClassMethods
           klass.send(:include, InstanceMethods)
+        end
+
+        def self.verify_sorcery_submodules_compatibility
+          active_submodules = [::Sorcery::Controller::Config.submodules].flatten
+
+          if active_submodules.include?(:activity_logging) && !repository.adapter.is_a?(::DataMapper::Adapters::MysqlAdapter)
+            raise "DataMapper adapter compatibility error, please check documentation"
+          end
         end
 
         module InstanceMethods

--- a/lib/sorcery/model/submodules/activity_logging.rb
+++ b/lib/sorcery/model/submodules/activity_logging.rb
@@ -28,12 +28,6 @@ module Sorcery
             reset!
           end
 
-          if defined?(DataMapper) and base.ancestors.include?(DataMapper::Resource)
-            # NOTE raise exception if data-store is not supported
-            unless base.repository.adapter.is_a?(DataMapper::Adapters::MysqlAdapter)
-              raise 'Unsupported DataMapper Adapter'
-            end
-          end
           base.sorcery_config.after_config << :define_activity_logging_fields
         end
         

--- a/spec/data_mapper/user_activity_logging_spec.rb
+++ b/spec/data_mapper/user_activity_logging_spec.rb
@@ -6,4 +6,9 @@ describe User, "with activity logging submodule", :data_mapper => true do
 
   it_behaves_like "rails_3_activity_logging_model"
 
+  it "raises an error when incompatible adapter" do
+    allow(User.repository.adapter).to receive(:is_a?).with(DataMapper::Adapters::MysqlAdapter) { false }
+    expect(-> { sorcery_reload!(:activity_logging) }).to raise_error(Exception)
+  end
+
 end


### PR DESCRIPTION
This is another step to decouple adapters from the rest of the library. In the
future mechanism of checking for compatibility can be extended, so that plugins
may add their own verifications, but right now it's not necessary.
