### PR TITLE
Add a more generic build_from method to external

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -164,6 +164,20 @@ module Sorcery
             return user
           end
 
+          def build_from(provider_name)
+            sorcery_fetch_user_hash provider_name
+            config = user_class.sorcery_config
+
+            attrs = user_attrs(@provider.user_info_mapping, @user_hash)
+
+            @user = user_class.new
+            attrs.each do |k,v|
+              @user.send(:"#{k}=", v)
+            end
+            @user.send(config.authentications_class.to_s.downcase.pluralize).build(config.provider_uid_attribute_name => @user_hash[:uid], config.provider_attribute_name => provider_name)
+            @user
+          end
+          
           # this method automatically creates a new user from the data in the external user hash.
           # The mappings from user hash fields to user db fields are set at controller config.
           # If the hash field you would like to map is nested, use slashes. For example, Given a hash like:

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -195,6 +195,17 @@ class SorceryController < ActionController::Base
       redirect_to 'blu', alert: 'Failed!'
     end
   end
+  
+  def test_build_from_provider
+    provider = params[:provider]
+    login_from(provider)
+    @user = build_from(provider)
+    if @user.save
+      redirect_to 'bla', notice: 'Success!'
+    else
+      redirect_to 'blu', alert: 'Failed!'
+    end
+  end
 
   def test_add_second_provider
     provider = params[:provider]

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -13,6 +13,7 @@ AppRoot::Application.routes.draw do
     get :test_logout_with_remember
     get :test_should_be_logged_in
     get :test_create_from_provider
+    get :test_build_from_provider
     get :test_add_second_provider
     get :test_return_to_with_external
     get :test_login_from

--- a/spec/shared_examples/controller_oauth2_shared_examples.rb
+++ b/spec/shared_examples/controller_oauth2_shared_examples.rb
@@ -49,4 +49,20 @@ shared_examples_for 'oauth2_controller' do
 
     end
   end
+
+  describe 'using build_from' do
+    before(:each) do
+      stub_all_oauth2_requests!
+      User.delete_all
+      Authentication.delete_all
+    end
+
+    it 'builds and saves a new user' do
+      sorcery_model_property_set(:authentications_class, Authentication)
+      sorcery_controller_external_property_set(:facebook, :user_info_mapping, { username: 'name' })
+
+      expect { get :test_build_from_provider, provider: 'facebook' }.to change { User.count }.by 1
+      expect(User.first.username).to eq 'Noam Ben Ari'
+    end
+  end
 end


### PR DESCRIPTION
the existing `create_from` does a lot of things, including a call to `save(validate: false)`. This is a generic version that can be better adapted to your needs
