### PR TITLE
Should we have a setup_activation method that saves to database?

### DIFF
--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -103,6 +103,11 @@ module Sorcery
             self.send(:"#{config.activation_token_expires_at_attribute_name}=", Time.now.in_time_zone + config.activation_token_expiration_period) if config.activation_token_expiration_period
           end
 
+          def setup_activation!
+            setup_activation
+            sorcery_adapter.save(:validate => false, :raise_on_failure => true)
+          end
+
           # clears activation code, sets the user as 'active' and optionaly sends a success email.
           def activate!
             config = sorcery_config


### PR DESCRIPTION
Just raising this pull request as a discussion to see if we should be adding this behaviour, or leaving it to the individual to implement on their own.

The reason is that when I saw that there was a `setup_activation` method, I assumed that it also wrote to the database -- but this turned out not to be true.

I added the following instance method:

``` ruby
def setup_activation!
  setup_activation
  sorcery_adapter.save(:validate => false, :raise_on_failure => true)
end
```

Then I realised I could just have easily did the following in my own project:

``` ruby
user.setup_activation
user.save
```

Which should we prefer?
