### PR TITLE
No return url on some formats

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -21,7 +21,7 @@ module Sorcery
       # If all attempts to auto-login fail, the failure callback will be called.
       def require_login
         if !logged_in?
-          session[:return_to_url] = request.url if Config.save_return_to_url && request.get?
+          session[:return_to_url] = request.url if Config.save_return_to_url && request.get? && !request.xhr?
           self.send(Config.not_authenticated_action)
         end
       end


### PR DESCRIPTION
Ajax request should not be considered as return url.
