### PR TITLE
User.create_from_provider with empty password fix

### DIFF
--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -2,8 +2,8 @@ class SorceryCore < ActiveRecord::Migration
   def change
     create_table :<%= model_class_name.tableize %> do |t|
       t.string :email,            :null => false
-      t.string :crypted_password, :null => false
-      t.string :salt,             :null => false
+      t.string :crypted_password
+      t.string :salt
 
       t.timestamps
     end

--- a/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
+++ b/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
@@ -3,8 +3,8 @@ class CreateUsers < ActiveRecord::Migration
     create_table :users do |t|
       t.string :username,         :null => false
       t.string :email,            :default => nil
-      t.string :crypted_password, :default => nil
-      t.string :salt,             :default => nil
+      t.string :crypted_password
+      t.string :salt
 
       t.timestamps
     end


### PR DESCRIPTION
Test and core migration databases were different: core DB does not accept null value for crypted_password, test DB accepted it. As a result, create_from_provider will fail with an SQL exception

``` ruby
SQLite3::ConstraintException: NOT NULL constraint failed: users.crypted_password
```

Adding "null: false" to crypted_password and salt inside spec/rails_app/db/migrate/core/20101224223620_create_users.rb will break 23 specs too.
