### PR TITLE
Use #deliver_now if using Rails 4.2+

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -177,7 +177,12 @@ module Sorcery
         config = sorcery_config
         mail = config.send(mailer).send(config.send(method),self)
         if defined?(ActionMailer) and config.send(mailer).kind_of?(Class) and config.send(mailer) < ActionMailer::Base
-          mail.deliver
+          # Rails 4.2 deprecates #deliver
+          if mail.respond_to?(:deliver_now)
+            mail.deliver_now
+          else
+            mail.deliver
+          end
         end
       end
     end


### PR DESCRIPTION
Rails 4.2.0.beta2 deprecates `ActionMailer::MessageDelivery#deliver` in favour of `#deliver_now` and `#deliver_later`.

This removes the deprecation warning produced by calling the `#deliver_reset_password_instructions!` method on the sorcery model when working on 4.2.0.beta2 and above.
