### PR TITLE
fix generator authentications index

### DIFF
--- a/lib/generators/sorcery/templates/migration/external.rb
+++ b/lib/generators/sorcery/templates/migration/external.rb
@@ -7,6 +7,6 @@ class SorceryExternal < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= model_class_name.tableize %>, [:provider, :uid]
+    add_index :authentications, [:provider, :uid]
   end
 end


### PR DESCRIPTION
Using this guide https://github.com/NoamB/sorcery/wiki/External . I get following error
```
Index name 'index_users_on_provider_and_uid' on table 'users' does not exist
ArgumentError: Index name 'index_users_on_provider_and_uid' on table 'users' does not exist
```