### PR TITLE
Add support of Facebook new Graph API v2 + test

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -119,8 +119,9 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.secret = ""
   # config.facebook.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=facebook"
   # config.facebook.user_info_mapping = {:email => "name"}
-  # config.facebook.access_permissions = ["email", "publish_stream"]
+  # config.facebook.access_permissions = ["email", "publish_actions"]
   # config.facebook.display = "page"
+  # config.facebook.api_version = "v2.2"
   #
   # config.github.key = ""
   # config.github.secret = ""

--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -12,7 +12,7 @@ module Sorcery
 
       attr_reader   :mode, :param_name, :parse
       attr_accessor :access_permissions, :display, :scope, :token_url,
-                    :user_info_path, :authorized_url, :api_version
+                    :user_info_path, :auth_path, :api_version
 
       def initialize
         super
@@ -22,7 +22,7 @@ module Sorcery
         @scope          = 'email,offline_access'
         @display        = 'page'
         @token_url      = 'oauth/access_token'
-        @authorized_url = 'oauth/authorize'
+        @auth_path      = 'oauth/authorize'
         @mode           = :query
         @parse          = :query
         @param_name     = 'access_token'
@@ -50,7 +50,7 @@ module Sorcery
         # concatenates with "/", removing the Facebook api version
         options = {
           site:          File::join(@site, api_version.to_s),
-          authorize_url: authorized_url,
+          authorize_url: auth_path,
           token_url:     token_url
         }
 

--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -19,7 +19,7 @@ module Sorcery
 
         @site           = 'https://graph.facebook.com'
         @user_info_path = 'me'
-        @scope          = 'email,offline_access'
+        @scope          = 'email'
         @display        = 'page'
         @token_url      = 'oauth/access_token'
         @auth_path      = 'oauth/authorize'

--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -12,16 +12,17 @@ module Sorcery
 
       attr_reader   :mode, :param_name, :parse
       attr_accessor :access_permissions, :display, :scope, :token_url,
-                    :user_info_path
+                    :user_info_path, :authorized_url, :api_version
 
       def initialize
         super
 
         @site           = 'https://graph.facebook.com'
-        @user_info_path = '/me'
+        @user_info_path = 'me'
         @scope          = 'email,offline_access'
         @display        = 'page'
         @token_url      = 'oauth/access_token'
+        @authorized_url = 'oauth/authorize'
         @mode           = :query
         @parse          = :query
         @param_name     = 'access_token'
@@ -44,8 +45,17 @@ module Sorcery
 
       # overrides oauth2#authorize_url to allow customized scope.
       def authorize_url
+
+        # Fix: replace default oauth2 options, specially to prevent the Faraday gem which
+        # concatenates with "/", removing the Facebook api version
+        options = {
+          site:          File::join(@site, api_version.to_s),
+          authorize_url: authorized_url,
+          token_url:     token_url
+        }
+
         @scope = access_permissions.present? ? access_permissions.join(',') : scope
-        super
+        super(options)
       end
 
       # tries to login the user from access token

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -90,6 +90,12 @@ describe SorceryController, :active_record => true do
         expect(response).to be_a_redirect
         expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email%2Coffline_access&state=bla")
       end
+      it "logins with Graph API version" do
+        sorcery_controller_external_property_set(:facebook, :api_version, "v2.2")
+        get :login_at_test_with_state
+        expect(response).to be_a_redirect
+        expect(response).to redirect_to("https://graph.facebook.com/v2.2/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email%2Coffline_access&state=bla")
+      end
       after do
         sorcery_controller_external_property_set(:facebook, :callback_url, "http://blabla.com")
       end

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -83,18 +83,18 @@ describe SorceryController, :active_record => true do
       it "login_at redirects correctly" do
         get :login_at_test_facebook
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email%2Coffline_access&state=")
+        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
       end
       it "logins with state" do
         get :login_at_test_with_state
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email%2Coffline_access&state=bla")
+        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
       end
       it "logins with Graph API version" do
         sorcery_controller_external_property_set(:facebook, :api_version, "v2.2")
         get :login_at_test_with_state
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/v2.2/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email%2Coffline_access&state=bla")
+        expect(response).to redirect_to("https://graph.facebook.com/v2.2/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
       end
       after do
         sorcery_controller_external_property_set(:facebook, :callback_url, "http://blabla.com")
@@ -108,7 +108,7 @@ describe SorceryController, :active_record => true do
         create_new_user
         get :login_at_test2
         response.should be_a_redirect
-        response.should redirect_to("https://graph.facebook.com/oauth/authorize?response_type=code&client_id=#{::Sorcery::Controller::Config.facebook.key}&redirect_uri=http%3A%2F%2Fblabla.com&scope=email%2Coffline_access&display=page&state")
+        response.should redirect_to("https://graph.facebook.com/oauth/authorize?response_type=code&client_id=#{::Sorcery::Controller::Config.facebook.key}&redirect_uri=http%3A%2F%2Fblabla.com&scope=email&display=page&state")
       end
     end
 =end


### PR DESCRIPTION
Add support of Facebook Graph API v2.

The major problem was in the Faraday gem: when a `/` is present in the string, the concatenation don't remove only the `/`, but also the string itself, removing the version at the end. So as a workaround, none of the string (which are going to be concatenate) have to start or end with a `/`.
I also replaced deprecated permissions and an `api_version` setter in the initializer.

Hope this is gonna be fine for you :)