### PR TITLE
Fix Facebook login auto redirect to a Graph API V1 when specifying a V2 + fix tests

### DIFF
--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -18,11 +18,12 @@ module Sorcery
         super
 
         @site           = 'https://graph.facebook.com'
+        @auth_site      = 'https://www.facebook.com'
         @user_info_path = 'me'
         @scope          = 'email'
         @display        = 'page'
         @token_url      = 'oauth/access_token'
-        @auth_path      = 'oauth/authorize'
+        @auth_path      = 'dialog/oauth'
         @mode           = :query
         @parse          = :query
         @param_name     = 'access_token'
@@ -50,7 +51,7 @@ module Sorcery
         # concatenates with "/", removing the Facebook api version
         options = {
           site:          File::join(@site, api_version.to_s),
-          authorize_url: auth_path,
+          authorize_url: File::join(@auth_site, api_version.to_s, auth_path),
           token_url:     token_url
         }
 

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -83,18 +83,18 @@ describe SorceryController, :active_record => true do
       it "login_at redirects correctly" do
         get :login_at_test_facebook
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
+        expect(response).to redirect_to("https://www.facebook.com/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
       end
       it "logins with state" do
         get :login_at_test_with_state
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
+        expect(response).to redirect_to("https://www.facebook.com/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
       end
       it "logins with Graph API version" do
         sorcery_controller_external_property_set(:facebook, :api_version, "v2.2")
         get :login_at_test_with_state
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://graph.facebook.com/v2.2/oauth/authorize?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
+        expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
       end
       after do
         sorcery_controller_external_property_set(:facebook, :callback_url, "http://blabla.com")


### PR DESCRIPTION
Hi again @arnvald !

My first fix #676 came with fixing deprecation called for the new Facebook Graph API V2 and ability to specify the version we want to call.

But seems that the actual `oauth/authorize` url is an automatic redirection operated by Facebook. It is redirecting a V2 request to a V1 url: `https://graph.facebook.com/v2.2/oauth/authorize?...` => `https://www.facebook.com/dialog/oauth?...` (as you can see, the version disappeared). Because it is a Facebook behavior, we cannot control it.

So here is a workaround, also adopted by [omniauth-facebook](https://github.com/mkdynamic/omniauth-facebook#api-version):
- `@site` is still available for requests like `/me`, `/access_token`
- new `@auth_site` to force the request versioning
- `@auth_path` has been updated with the new versioned path

Finally, the login url will become:
- `https://www.facebook.com/dialog/oauth` non versioned request
- `https://www.facebook.com/v2.2/dialog/oauth` v2.2 request

**Note:**
- *when no version is filled in the sorcery configuration, the default non versioned request is called.*
- *the non versioned request is an auto redirect made by Facebook. So if you do not specify a version, this one is going to be a V1.0 up to april 30th 2015, then it will automatically become a V2.0*
- *the old `oauth/authorize` url is and will still working, it is simply the equivalent of non versioned `dialog/oauth` auto redirecting by Facebook*