### PR TITLE
Fix LoadError

### DIFF
--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -12,10 +12,5 @@ module Sorcery
       ActionController::Base.helper_method :current_user
       ActionController::Base.helper_method :logged_in?
     end
-    
-    rake_tasks do
-      load "sorcery/railties/tasks.rake"
-    end
-    
   end
 end


### PR DESCRIPTION
Hi @arnvald 

I fixed following error:
```
$ rake db:migrate
rake aborted!
LoadError: cannot load such file -- sorcery/railties/tasks.rake
```

See also https://github.com/NoamB/sorcery/commit/bbc745672b4ab4ea04293dca60350dcf64b92f9a