### PR TITLE
fix access to user_hash in xing provider

### DIFF
--- a/lib/sorcery/providers/xing.rb
+++ b/lib/sorcery/providers/xing.rb
@@ -34,7 +34,7 @@ module Sorcery
 
         auth_hash(access_token).tap do |h|
           h[:user_info] = JSON.parse(response.body)['users'].first
-          h[:uid] = user_hash[:user_info]['id'].to_s
+          h[:uid] = h[:user_info]['id'].to_s
         end
       end
 


### PR DESCRIPTION
`user_hash` is not defined, using `h` instead. Xing-Login works again now. 