### PR TITLE
Fixes bug where UID is always blank when LinkedIn is the provider

### DIFF
--- a/lib/sorcery/providers/linkedin.rb
+++ b/lib/sorcery/providers/linkedin.rb
@@ -32,7 +32,7 @@ module Sorcery
 
       def get_user_hash(access_token)
         fields = self.user_info_fields.join(',')
-        response = access_token.get("#{@user_info_path}:(#{fields})", 'x-li-format' => 'json')
+        response = access_token.get("#{@user_info_path}:(id,#{fields})", 'x-li-format' => 'json')
 
         auth_hash(access_token).tap do |h|
           h[:user_info] = JSON.parse(response.body)


### PR DESCRIPTION
LinkedIn doesn't automatically return an `id` in v1/people/~ 

So, if you don't specify `id` in the call, the `uid` in `Authentications` will be blank, and only the first user will be created 'successfully'. This change makes LinkedIn work out of the box with Sorcery by adding `id` to the call by default. For instance, Facebook works out of the box this way already (no need for the developer to specify `id` in the initializer).

I was pulling my hair out today trying to figure out why I couldn't create more than one LinkedIn user, while Facebook was creating users just fine in the same app.

Until this pull request is accepted - anyone using LinkedIn will need to explicitly add `id` in their config/initializers/sorcery.rb, like this:

`config.linkedin.user_info_fields = ['id', 'first-name', 'last-name']`

Also worth noting: Asking for any field twice returns a '400 - Duplicate field...' error, and will cause authentication with LinkedIn to fail. So, anyone specifying `id` in their config would need to remove it after this PR.