### PR TITLE
Add logged_in? and online? status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Adapters (Mongoid, MongoMapper, DataMapper) are now separated from the core Sorcery repo and moved under `sorcery-rails` organization. Special thanks to @juike!
 * `current_users` method was removed
+* Added `logged_in?` `logged_out?` `online?` to activity_logging instance methods
 
 ## 0.9.1
 

--- a/spec/shared_examples/user_activity_logging_shared_examples.rb
+++ b/spec/shared_examples/user_activity_logging_shared_examples.rb
@@ -59,5 +59,49 @@ shared_examples_for "rails_3_activity_logging_model" do
 
       user.set_last_ip_addess('0.0.0.0')
     end
+
+    it 'show if user logged in' do
+      user = create_new_user
+      expect(user.logged_in?).to eq(false)
+
+      now = Time.now.in_time_zone
+      user.set_last_login_at(now)
+      expect(user.logged_in?).to eq(true)
+
+      now = Time.now.in_time_zone
+      user.set_last_logout_at(now)
+      expect(user.logged_in?).to eq(false)
+    end
+
+    it 'show if user logged out' do
+      user = create_new_user
+      expect(user.logged_out?).to eq(true)
+
+      now = Time.now.in_time_zone
+      user.set_last_login_at(now)
+      expect(user.logged_out?).to eq(false)
+
+      now = Time.now.in_time_zone
+      user.set_last_logout_at(now)
+      expect(user.logged_out?).to eq(true)
+    end
+
+    it 'show online status of user' do
+      user = create_new_user
+      expect(user.online?).to eq(false)
+
+      now = Time.now.in_time_zone
+      user.set_last_login_at(now)
+      user.set_last_activity_at(now)
+      expect(user.online?).to eq(true)
+
+      user.set_last_activity_at(now - 1.day)
+      expect(user.online?).to eq(false)
+
+      now = Time.now.in_time_zone
+      user.set_last_logout_at(now)
+      expect(user.online?).to eq(false)
+    end
+
   end
 end


### PR DESCRIPTION
I found that in v1 current users will be removed.

But it's useful to know if user is logged in or active.
Thats why each user can have methods 
`
logged_in?
logged_out?
active?
`