### PR TITLE
Add Yahoo! JAPAN provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ STI is supported via a single setting in config/initializers/sorcery.rb.
 **External** (see [lib/sorcery/controller/submodules/external.rb](https://github.com/NoamB/sorcery/blob/master/lib/sorcery/controller/submodules/external.rb)):
 
 *   OAuth1 and OAuth2 support (currently: Twitter, Facebook, Github, Google, Heroku,
-    LinkedIn, VK, LiveID, Xing, and Salesforce)
+    LinkedIn, VK, LiveID, Xing, Salesforce and Yahoo! JAPAN)
 *   configurable db field names and authentications table.
 
 

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -73,7 +73,7 @@ Rails.application.config.sorcery.configure do |config|
 
 
   # -- external --
-  # What providers are supported by this app, i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce] .
+  # What providers are supported by this app, i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :yahoojp] .
   # Default: `[]`
   #
   # config.external_providers =
@@ -171,6 +171,12 @@ Rails.application.config.sorcery.configure do |config|
   # config.salesforce.callback_url = "https://127.0.0.1:9292/oauth/callback?provider=salesforce"
   # config.salesforce.scope = "full"
   # config.salesforce.user_info_mapping = {:email => "email"}
+
+  # For information about Yahoo! JAPAN: http://developer.yahoo.co.jp/yconnect/
+  # config.yahoojp.key = ''
+  # config.yahoojp.secret = ''
+  # config.yahoojp.callback_url = 'http://0.0.0.0:3000/oauth/callback?provider=yahoojp'
+  # config.yahoojp.scope = 'openid email'
 
   # --- user config ---
   config.user_config do |user|

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -19,6 +19,7 @@ module Sorcery
           require 'sorcery/providers/google'
           require 'sorcery/providers/jira'
           require 'sorcery/providers/salesforce'
+          require 'sorcery/providers/yahoojp'
 
           Config.module_eval do
             class << self

--- a/lib/sorcery/protocols/oauth2.rb
+++ b/lib/sorcery/protocols/oauth2.rb
@@ -24,7 +24,8 @@ module Sorcery
           args[:code],
           {
             redirect_uri: @callback_url,
-            parse: options.delete(:parse)
+            parse: options.delete(:parse),
+            headers: options.delete(:headers)
           },
           options
         )

--- a/lib/sorcery/providers/yahoojp.rb
+++ b/lib/sorcery/providers/yahoojp.rb
@@ -1,0 +1,68 @@
+module Sorcery
+  module Providers
+    # This class adds support for OAuth with yahoo.co.jp.
+    #
+    #   config.yahoojp.key = <key>
+    #   config.yahoojp.secret = <secret>
+    #   ...
+    #
+    class Yahoojp < Base
+
+      include Protocols::Oauth2
+
+      attr_accessor :auth_path, :token_path, :user_info_url, :scope
+
+      def initialize
+        super
+
+        @site          = 'https://auth.login.yahoo.co.jp'
+        @auth_path     = '/yconnect/v1/authorization'
+        @token_path    = '/yconnect/v1/token'
+        @user_info_url = 'https://userinfo.yahooapis.jp/yconnect/v1/attribute?schema=openid'
+        @scope         = 'openid'
+      end
+
+      def get_user_hash(access_token)
+        response = access_token.get(user_info_url)
+
+        auth_hash(access_token).tap do |h|
+          h[:user_info] = JSON.parse(response.body)
+          h[:uid] = h[:user_info]['user_id']
+        end
+      end
+
+      # calculates and returns the url to which the user should be redirected,
+      # to get authenticated at the external provider's site.
+      def login_url(params, session)
+        authorize_url(authorize_url: auth_path)
+      end
+
+      # tries to login the user from access token
+      def process_callback(params, session)
+        args = {}.tap do |a|
+          a[:code] = params[:code] if params[:code]
+        end
+
+        basic_auth = Base64.encode64("#{key}:#{secret}").gsub("\n", '')
+        headers = { 'Authorization' => "Basic #{basic_auth}" }
+        get_access_token(args, token_url: token_path, token_method: :post, headers: headers)
+      end
+
+      def build_client(options = {})
+        if options[:headers] && options[:headers]['Authorization']
+          # OAuth2::Client does not support the HTTP Basic authentication.
+          # https://github.com/intridea/oauth2/pull/192
+          # http://tools.ietf.org/html/rfc6749#section-2.3.1
+          defaults = {
+            site: @site,
+            ssl: { ca_file: Sorcery::Controller::Config.ca_file }
+          }
+          ::OAuth2::Client.new(nil, nil, defaults.merge!(options))
+        else
+          super
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I have added a provider for Yahoo! JAPAN: http://www.yahoo.co.jp/. 
This yahoo_jp brunch has been deployed to our production env and this yahoojp provider works fine.
Of course, other providers, google and facebook, still works fine.

Thank you for this great gem, I'd like to contribute it.
