### PR TITLE
allow options hash as an argument to change_password!

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -105,10 +105,10 @@ module Sorcery
           end
 
           # Clears token and tries to update the new password for the user.
-          def change_password!(new_password)
+          def change_password!(new_password, options={})
             clear_reset_password_token
             self.send(:"#{sorcery_config.password_attribute_name}=", new_password)
-            sorcery_adapter.save
+            sorcery_adapter.save(options)
           end
 
           protected

--- a/lib/sorcery/providers/twitter.rb
+++ b/lib/sorcery/providers/twitter.rb
@@ -25,6 +25,8 @@ module Sorcery
       end
 
       def get_user_hash(access_token)
+        # You must have been granted access to User email by Twitter and have set up your app to request email
+        @user_info_path = @user_info_path + '?include_email=true' if user_info_mapping.keys.include?(:email)
         response = access_token.get(user_info_path)
 
         auth_hash(access_token).tap do |h|


### PR DESCRIPTION
change_password! ends up delegating to ```Sorcery::Adapters::ActiveRecordAdapter#save``` to save the model.  Since ```Sorcery::Adapters::ActiveRecordAdapter#save```already supports an options hash, this would allow passing options such as ```validate: false``` to #change_password!