### PR TITLE
allow options hash as an argument to change_password!

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -105,10 +105,10 @@ module Sorcery
           end
 
           # Clears token and tries to update the new password for the user.
-          def change_password!(new_password)
+          def change_password!(new_password, options={})
             clear_reset_password_token
             self.send(:"#{sorcery_config.password_attribute_name}=", new_password)
-            sorcery_adapter.save
+            sorcery_adapter.save(options)
           end
 
           protected


### PR DESCRIPTION
```change_password!``` delegates to ```Sorcery::Adapters::ActiveRecordAdapter``` to save the model. 

since ```Sorcery::Adapters::ActiveRecordAdapter#save``` already supports an options hash, this would allow passing options such as ```validate: false``` to ```change_password!```