### PR TITLE
it IS possible to get users' email via Twitter v1.1 OAuth but we need a tweak...

### DIFF
--- a/lib/sorcery/providers/twitter.rb
+++ b/lib/sorcery/providers/twitter.rb
@@ -25,6 +25,8 @@ module Sorcery
       end
 
       def get_user_hash(access_token)
+        # You must have been granted access to User email by Twitter and have set up your app to request email
+        @user_info_path = @user_info_path + '?include_email=true' if user_info_mapping.keys.include?(:email)
         response = access_token.get(user_info_path)
 
         auth_hash(access_token).tap do |h|


### PR DESCRIPTION
If you peruse this thread: https://twittercommunity.com/t/how-to-get-email-from-twitter-user-using-oauthtokens/558/202
you will find enough information on getting user emails out of Twitter.  

Here's a quick summary:

1. Use this form https://support.twitter.com/forms/platform and click 'I need access to special permissions'
1. Fill out the form with all relevant info, requesting that you would like access to user emails and click Submit.
1. This will generate an email from Twitter explaining their policy towards user email access.  It will reference XAuth - don't worry that means OAuth too for them.  Reply to the email as per their instructions - I DID NOT have to send them a link to a video however.
1. You should receive another email from Twitter within 24 hours granting you access.
1. Go back to your App page on Twitter, fill in Privacy Policy and User Agreement links as they request.  Save your changes.
1. On the 'Permissions' tab of your App page, enable asking for User email.  Save your changes.

After doing all of that, I will still not getting user email by just setting ```email: 'email'``` in Sorcery's twitter config ```config.twitter.user_info_mapping```.

Debugging the request Sorcery was making for user info, I found that appending 'include_email=true' to the 'verify_credentials.json' endpoint did the trick.  

I looked around for as clean as possible a way to add this but without modifying Sorcery configs, this was the quickest way for me to keep working.  Hope it helps out.