### PR TITLE
add test-unit to development dependencies

### DIFF
--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", ">= 0.3.8"
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rspec-rails", "~> 3.0.0"
+  s.add_development_dependency "test-unit", "~> 3.1.0"
 end
 


### PR DESCRIPTION
I cloned repo. Run `bundle`. Ran `rspec spec/`. Got a fail saying that cannot require `test/unit/assertions`.

    $rspec spec
    /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails/adapters.rb:23:in `require': cannot load such file -- test/unit/assertions (LoadError)
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails/adapters.rb:23:in `rescue in <module:Rails>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails/adapters.rb:18:in `<module:Rails>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails/adapters.rb:6:in `<module:RSpec>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails/adapters.rb:5:in `<top (required)>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails.rb:5:in `require'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-rails-3.0.2/lib/rspec/rails.rb:5:in `<top (required)>'
        from /home/hubert/Projekty/sorcery/spec/spec_helper.rb:15:in `require'
        from /home/hubert/Projekty/sorcery/spec/spec_helper.rb:15:in `<top (required)>'
        from /home/hubert/Projekty/sorcery/spec/active_record/user_activation_spec.rb:1:in `require'
        from /home/hubert/Projekty/sorcery/spec/active_record/user_activation_spec.rb:1:in `<top (required)>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `block in load_spec_files'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `each'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load_spec_files'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:97:in `setup'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:85:in `run'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:70:in `run'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:38:in `invoke'
        from /home/hubert/.rvm/gems/ruby-2.2.2/gems/rspec-core-3.0.4/exe/rspec:4:in `<top (required)>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/bin/rspec:23:in `load'
        from /home/hubert/.rvm/gems/ruby-2.2.2/bin/rspec:23:in `<main>'
        from /home/hubert/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
        from /home/hubert/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'

I guess I did not had test/unit on hand and it is required in the end. This PR fixes the issue forme.

Or should I rather differently run tests?