### PR TITLE
Add scope_for_authentication method to find records

### DIFF
--- a/lib/sorcery/adapters/active_record_adapter.rb
+++ b/lib/sorcery/adapters/active_record_adapter.rb
@@ -44,11 +44,11 @@ module Sorcery
             @user_config.provider_attribute_name     => provider
           }
 
-          @klass.where(conditions).first
+          scope_for_authentication.where(conditions).first
         end
 
         def find_by_remember_me_token(token)
-          @klass.where(@klass.sorcery_config.remember_me_token_attribute_name => token).first
+          scope_for_authentication.where(@klass.sorcery_config.remember_me_token_attribute_name => token).first
         end
 
         def find_by_credentials(credentials)
@@ -68,21 +68,21 @@ module Sorcery
             end
           end
 
-          @klass.where(relation).first
+          scope_for_authentication.where(relation).first
         end
 
         def find_by_token(token_attr_name, token)
           condition = @klass.arel_table[token_attr_name].eq(token)
 
-          @klass.where(condition).first
+          scope_for_authentication.where(condition).first
         end
 
         def find_by_activation_token(token)
-          @klass.where(@klass.sorcery_config.activation_token_attribute_name => token).first
+          scope_for_authentication.where(@klass.sorcery_config.activation_token_attribute_name => token).first
         end
 
         def find_by_id(id)
-          @klass.find_by_id(id)
+          scope_for_authentication.find_by_id(id)
         end
 
         def find_by_username(username)
@@ -91,13 +91,13 @@ module Sorcery
               username = username.downcase
             end
 
-            result = @klass.where(attribute => username).first
+            result = scope_for_authentication.where(attribute => username).first
             return result if result
           end
         end
 
         def find_by_email(email)
-          @klass.where(@klass.sorcery_config.email_attribute_name => email).first
+          scope_for_authentication.where(@klass.sorcery_config.email_attribute_name => email).first
         end
 
         def transaction(&blk)

--- a/lib/sorcery/adapters/base_adapter.rb
+++ b/lib/sorcery/adapters/base_adapter.rb
@@ -25,6 +25,10 @@ module Sorcery
       def update_attribute(name, value)
         update_attributes(name => value)
       end
+
+      def self.scope_for_authentication
+        @klass.respond_to?(:scope_for_authentication) ? @klass.scope_for_authentication : @klass.where({})
+      end
     end
   end
 end

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -151,6 +151,21 @@ shared_examples_for "rails_3_core_model" do
           expect(User.authenticate user.email, 'secret').to be_nil
         end
       end
+
+      context "and model implements scope_for_authentication" do
+
+        it "authenticates returns user if this user is being found by scope" do
+          allow(User).to receive(:scope_for_authentication) { User.where({}) }
+
+          expect(User.authenticate user.email, 'secret').to eq user
+        end
+
+        it "authenticate returns nil if scope_for_authentication returns false" do
+          allow(User).to receive(:scope_for_authentication) { User.where('"1" = "2"') }
+
+          expect(User.authenticate user.email, 'secret').to be_nil
+        end
+      end
     end
 
     specify { expect(User).to respond_to(:encrypt) }


### PR DESCRIPTION
So I was trying to do exactly as this guy over here https://github.com/NoamB/sorcery/issues/723

I figured I need a scope, and I do not like the `default_scope` solution.

This commit uses `scope_for_authentication` method, if defined on given class, to find the record in question. In my case, this is implemented as `where("deleted_at is not null")` but I guess there are other use cases or conditions that you might want to apply in similar manner.

Please have a loook, and if you find it useful merge. If no, no harm done, I'll keep my fork for this single app for time being until I find better solution.

