### PR TITLE
Google provider accepts additional authentication params

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -133,6 +133,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
   # config.google.user_info_mapping = {:email => "email", :username => "name"}
   # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+  # config.google.auth_params = {}
   #
   # config.vk.key = ""
   # config.vk.secret = ""

--- a/lib/sorcery/providers/google.rb
+++ b/lib/sorcery/providers/google.rb
@@ -10,7 +10,7 @@ module Sorcery
 
       include Protocols::Oauth2
 
-      attr_accessor :auth_url, :scope, :token_url, :user_info_url
+      attr_accessor :auth_url, :scope, :token_url, :user_info_url, :auth_params
 
       def initialize
         super
@@ -34,7 +34,7 @@ module Sorcery
       # calculates and returns the url to which the user should be redirected,
       # to get authenticated at the external provider's site.
       def login_url(params, session)
-        authorize_url({ authorize_url: auth_url })
+        authorize_url({ authorize_url: auth_url_with_params })
       end
 
       # tries to login the user from access token
@@ -46,6 +46,11 @@ module Sorcery
         get_access_token(args, token_url: token_url, token_method: :post)
       end
 
+      private
+      def auth_url_with_params
+        param_string = Faraday::Utils::ParamsHash[auth_params || {}].to_query
+        [auth_url, param_string].join('?')
+      end
     end
   end
 end

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -405,6 +405,7 @@ describe SorceryController, :active_record => true do
     sorcery_controller_external_property_set(:google, :key, "eYVNBjBDi33aa9GkA3w")
     sorcery_controller_external_property_set(:google, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
     sorcery_controller_external_property_set(:google, :callback_url, "http://blabla.com")
+    sorcery_controller_external_property_set(:google, :auth_params, access_type: :offline)
     sorcery_controller_external_property_set(:liveid, :key, "eYVNBjBDi33aa9GkA3w")
     sorcery_controller_external_property_set(:liveid, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
     sorcery_controller_external_property_set(:liveid, :callback_url, "http://blabla.com")
@@ -419,7 +420,7 @@ describe SorceryController, :active_record => true do
   def provider_url(provider)
     {
       github: "https://github.com/login/oauth/authorize?client_id=#{::Sorcery::Controller::Config.github.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=&state=",
-      google: "https://accounts.google.com/o/oauth2/auth?client_id=#{::Sorcery::Controller::Config.google.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=",
+      google: "https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=#{::Sorcery::Controller::Config.google.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state=",
       liveid: "https://oauth.live.com/authorize?client_id=#{::Sorcery::Controller::Config.liveid.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=wl.basic+wl.emails+wl.offline_access&state=",
       vk: "https://oauth.vk.com/authorize?client_id=#{::Sorcery::Controller::Config.vk.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.vk.scope}&state=",
       salesforce: "https://login.salesforce.com/services/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.salesforce.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.salesforce.scope}&state="

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -83,7 +83,7 @@ describe SorceryController, :active_record => true do
       it "login_at redirects correctly" do
         get :login_at_test_facebook
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://www.facebook.com/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
+        expect(response).to redirect_to("https://www.facebook.com/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")
       end
 
       it "logins with state" do
@@ -104,7 +104,7 @@ describe SorceryController, :active_record => true do
         expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=bla")
 
         get :login_at_test_facebook
-        expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
+        expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")
       end
 
       after do
@@ -117,7 +117,7 @@ describe SorceryController, :active_record => true do
         create_new_user
         get :login_at_test_facebook
         expect(response).to be_a_redirect
-        expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state=")
+        expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")
       end
     end
 
@@ -423,7 +423,7 @@ describe SorceryController, :active_record => true do
       liveid: "https://oauth.live.com/authorize?client_id=#{::Sorcery::Controller::Config.liveid.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=wl.basic+wl.emails+wl.offline_access&state=",
       vk: "https://oauth.vk.com/authorize?client_id=#{::Sorcery::Controller::Config.vk.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.vk.scope}&state=",
       salesforce: "https://login.salesforce.com/services/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.salesforce.key}&display=&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.salesforce.scope}&state="
-    }[provider]
+    }[provider].gsub(/\=(&|$)/, '\1')
   end
 end
 


### PR DESCRIPTION
Allows setting `config.google.auth_params = {access_type: :offline, hd: 'mydomain.com'}`
Solves #702

A better solution might be to merge these params with the ones hard coded in `oauth2.rb` and passed to `client.auth_code.authorize_url`. That would then make it easier to extend this to other providers, e.g. to add include_email for #719. I've instead used the auth_url to avoid changing the `Sorcery::Protocols::Oauth2#authorize_url` method signature for everyone. If you prefer I'll add an extra argument there instead, i.e. `authorize_url(options = {}, auth_params = {})`.
