### PR TITLE
Clarify STI in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ end
 Sidekiq and Resque integrations are coming soon.
 
 ## Single Table Inheritance (STI) Support
-STI is supported via a single setting in config/initializers/sorcery.rb.
+STI is supported via the `user.subclasses_inherit_config` setting in config/initializers/sorcery.rb.
 
 ## Full Features List by module
 


### PR DESCRIPTION
I had to look through the source code to find this. The name of the config item doesn't correspond to the common name "Single Table Inheritance" so it was hard to find.