### PR TITLE
change_password vs. change_password!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `current_users` method was removed
 * Added `logged_in?` `logged_out?` `online?` to activity_logging instance methods
 * PayPal provider added to external submodule
+* Update the `change_password!` to raise exception when it fails to save, and add `change_password` method with the current behaviour (return `false` when it fails)
 
 ## 0.9.1
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ force_forget_me!    # completely forgets all sessions by clearing the token, eve
 User.load_from_reset_password_token(token)
 @user.generate_reset_password_token! # if you want to send the email by youself
 @user.deliver_reset_password_instructions! # generates the token and sends the email
-@user.change_password!(new_password)
+@user.change_password!(new_password) # will raise error on failure
+@user.change_password(new_password)  # will return false on failure
 ```
 
 ### user activation

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -107,10 +107,19 @@ module Sorcery
           end
 
           # Clears token and tries to update the new password for the user.
-          def change_password!(new_password)
+          # Returns false when it fails to save.
+          def change_password(new_password)
             clear_reset_password_token
             self.send(:"#{sorcery_config.password_attribute_name}=", new_password)
             sorcery_adapter.save
+          end
+
+          # Clears token and tries to update the new password for the user.
+          # Raises error when it fails to save.
+          def change_password!(new_password)
+            clear_reset_password_token
+            self.send(:"#{sorcery_config.password_attribute_name}=", new_password)
+            sorcery_adapter.save(:raise_on_failure => true)
           end
 
           protected

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -16,6 +16,7 @@ shared_examples_for "rails_3_reset_password_model" do
 
       specify { expect(user).to respond_to :deliver_reset_password_instructions! }
 
+      specify { expect(user).to respond_to :change_password }
       specify { expect(user).to respond_to :change_password! }
 
       it "responds to .load_from_reset_password_token" do
@@ -142,7 +143,7 @@ shared_examples_for "rails_3_reset_password_model" do
 
     it "'deliver_reset_password_instructions! returns a Mail::Message object" do
       expect(user.deliver_reset_password_instructions!).to be_an_instance_of Mail::Message
-    end 
+    end
 
     it "the reset_password_token is random" do
       sorcery_model_property_set(:reset_password_time_between_emails, 0)
@@ -238,13 +239,22 @@ shared_examples_for "rails_3_reset_password_model" do
       end
     end
 
+    it "when change_password is called, deletes reset_password_token" do
+      user.deliver_reset_password_instructions!
+
+      expect(user.reset_password_token).not_to be_nil
+
+      user.change_password("blabulsdf")
+
+      expect(user.reset_password_token).to be_nil
+    end
+
     it "when change_password! is called, deletes reset_password_token" do
       user.deliver_reset_password_instructions!
 
       expect(user.reset_password_token).not_to be_nil
 
       user.change_password!("blabulsdf")
-      user.save!
 
       expect(user.reset_password_token).to be_nil
     end

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -259,6 +259,16 @@ shared_examples_for "rails_3_reset_password_model" do
       expect(user.reset_password_token).to be_nil
     end
 
+    it "raises error when failing to change_password!" do
+      # insure that the model will fail validation on this test
+      update_model do
+        validates :password, length: { minimum: 1 }
+      end
+
+      expect { user.change_password!('') }.to\
+        raise_error ActiveRecord::RecordInvalid
+    end
+
     it "returns false if time between emails has not passed since last email" do
       sorcery_model_property_set(:reset_password_time_between_emails, 10000)
       user.deliver_reset_password_instructions!


### PR DESCRIPTION
check #744 
this PR fixes the methods names to follow the ruby (and rails) convention of using the bang methods to raise errors on failure instead of returning false
