### PR TITLE
Make remembe_me_token_key customizable

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -172,6 +172,12 @@ Rails.application.config.sorcery.configure do |config|
   # config.salesforce.scope = "full"
   # config.salesforce.user_info_mapping = {:email => "email"}
 
+  # Set remember_me_token cookie key.
+  # Useful for remember_me in submodules.
+  # Default: `:remember_me_token`
+  #
+  # config.remember_me_token_key =
+
   # --- user config ---
   config.user_config do |user|
     # -- core --

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -109,7 +109,7 @@ module Sorcery
 
       # Overwrite Rails' handle unverified request
       def handle_unverified_request
-        cookies[:remember_me_token] = nil
+        cookies[Config.remember_me_token_key] = nil
         @current_user = nil
         super # call the default behaviour which resets the session
       end

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -16,7 +16,8 @@ module Sorcery
                       :after_login,
                       :after_failed_login,
                       :before_logout,
-                      :after_logout
+                      :after_logout,
+                      :remember_me_token_key
 
         def init!
           @defaults = {
@@ -29,7 +30,8 @@ module Sorcery
             :@before_logout                        => [],
             :@after_logout                         => [],
             :@save_return_to_url                   => true,
-            :@cookie_domain                        => nil
+            :@cookie_domain                        => nil,
+            :@remember_me_token_key                => :remember_me_token
           }
         end
 

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -32,13 +32,13 @@ module Sorcery
           # Clears the cookie, and depending on the value of remember_me_token_persist_globally, may clear the token value.
           def forget_me!
             current_user.forget_me!
-            cookies.delete(:remember_me_token, :domain => Config.cookie_domain)
+            cookies.delete(remember_me_token_key, :domain => Config.cookie_domain)
           end
 
           # Clears the cookie, and clears the token value.
           def force_forget_me!
             current_user.force_forget_me!
-            cookies.delete(:remember_me_token, :domain => Config.cookie_domain)
+            cookies.delete(remember_me_token_key, :domain => Config.cookie_domain)
           end
 
           # Override.
@@ -61,7 +61,7 @@ module Sorcery
           # and logs the user in if found.
           # Runs as a login source. See 'current_user' method for how it is used.
           def login_from_cookie
-            user = cookies.signed[:remember_me_token] && user_class.sorcery_adapter.find_by_remember_me_token(cookies.signed[:remember_me_token])
+            user = cookies.signed[remember_me_token_key] && user_class.sorcery_adapter.find_by_remember_me_token(cookies.signed[remember_me_token_key])
             if user && user.has_remember_me_token?
               set_remember_me_cookie!(user)
               session[:user_id] = user.id.to_s
@@ -72,15 +72,18 @@ module Sorcery
           end
 
           def set_remember_me_cookie!(user)
-            cookies.signed[:remember_me_token] = {
+            cookies.signed[remember_me_token_key] = {
               :value => user.send(user.sorcery_config.remember_me_token_attribute_name),
               :expires => user.send(user.sorcery_config.remember_me_token_expires_at_attribute_name),
               :httponly => Config.remember_me_httponly,
               :domain => Config.cookie_domain
             }
           end
-        end
 
+          def remember_me_token_key
+            Config.remember_me_token_key
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
It's useful for the case below.

- Production env is `https://production.example.com`.
- Staging env is `https://staging.example.com`.
- And cookie domain is `.example.com`, and you must want to store `:remind_me_token` in each different keys.