### PR TITLE
Allow one-time skipping of activation-related emails for new users.

### DIFF
--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -112,6 +112,8 @@ module Sorcery
             sorcery_adapter.save(:validate => false, :raise_on_failure => true)
           end
 
+          attr_accessor :skip_activation_needed_email, :skip_activation_success_email
+
           protected
 
           # called automatically after user initial creation.
@@ -127,14 +129,14 @@ module Sorcery
             !external? && (
               !(sorcery_config.activation_success_email_method_name.nil? ||
                 sorcery_config.activation_mailer_disabled == true)
-            )
+            ) && !skip_activation_success_email
           end
 
           def send_activation_needed_email?
             !external? && (
               !(sorcery_config.activation_needed_email_method_name.nil? ||
                 sorcery_config.activation_mailer_disabled == true)
-            )
+            ) && !skip_activation_needed_email
           end
 
           def prevent_non_active_login

--- a/spec/shared_examples/user_activation_shared_examples.rb
+++ b/spec/shared_examples/user_activation_shared_examples.rb
@@ -149,6 +149,7 @@ shared_examples_for "rails_3_activation_model" do
 
       it "does not send the user an activation email" do
         old_size = ActionMailer::Base.deliveries.size
+        create_new_user
 
         expect(ActionMailer::Base.deliveries.size).to eq old_size
       end

--- a/spec/shared_examples/user_activation_shared_examples.rb
+++ b/spec/shared_examples/user_activation_shared_examples.rb
@@ -140,6 +140,48 @@ shared_examples_for "rails_3_activation_model" do
 
         expect(ActionMailer::Base.deliveries.size).to eq old_size
       end
+
+      context "activation_needed_email is skipped" do
+        before(:each) do
+          @user = build_new_user
+          @user.skip_activation_needed_email = true
+        end
+
+        it "does not send the user an activation email" do
+          old_size = ActionMailer::Base.deliveries.size
+
+          @user.sorcery_adapter.save(:raise_on_failure => true)
+
+          expect(ActionMailer::Base.deliveries.size).to eq old_size
+        end
+
+        it "does not call send_activation_needed_email! method of user" do
+          expect(@user).to receive(:send_activation_needed_email!).never
+
+          @user.sorcery_adapter.save(:raise_on_failure => true)
+        end
+
+        it "calls send_activation_success_email! method of user on activation" do
+          expect(@user).to receive(:send_activation_success_email!).never
+
+          @user.activate!
+        end
+      end
+
+      context "activation_success_email is skipped" do
+        before(:each) do
+          @user = build_new_user
+          @user.skip_activation_success_email = true
+        end
+
+        it "does not send the user an activation success email on successful activation" do
+          old_size = ActionMailer::Base.deliveries.size
+
+          @user.activate!
+
+          expect(ActionMailer::Base.deliveries.size).to eq old_size
+        end
+      end
     end
 
     context "mailer has been disabled" do


### PR DESCRIPTION
This is useful for special cases where you want to manage the emails yourself (but still want the default config to send the emails)

Activation Needed Example:
```ruby
special_user = User.new
special_user.skip_activation_needed_email = true
special_user.save! # activation needed email does not get sent
```
Activation Success Example:
```ruby
special_user = User.find(special_user_id)
special_user.skip_activation_success_email = true
special_user.activate! # activation success email does not get sent
```