### PR TITLE
Allow linkedin to function without user_info_fields set in config

### DIFF
--- a/lib/sorcery/providers/linkedin.rb
+++ b/lib/sorcery/providers/linkedin.rb
@@ -31,7 +31,9 @@ module Sorcery
       end
 
       def get_user_hash(access_token)
-        fields = self.user_info_fields.join(',')
+        fields = !self.user_info_fields.nil? ? 
+          self.user_info_fields.join(',')
+          : ""
         response = access_token.get("#{@user_info_path}:(id,#{fields})", 'x-li-format' => 'json')
 
         auth_hash(access_token).tap do |h|


### PR DESCRIPTION
`get_user_hash` tries to call `join` on `user_info_fields`, but it was not handling the case where it's not explicitly set in the config.