### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
 
 gemfile:
   - Gemfile
@@ -29,7 +29,7 @@ matrix:
     - rvm: 2.2
       gemfile: gemfiles/active_record-rails42.gemfile
 
-    - rvm: 2.3
+    - rvm: 2.3.0
       gemfile: gemfiles/active_record-rails42.gemfile
 
     - rvm: 1.9.3
@@ -44,7 +44,7 @@ matrix:
     - rvm: 2.2
       gemfile: gemfiles/active_record-rails41.gemfile
 
-    - rvm: 2.3
+    - rvm: 2.3.0
       gemfile: gemfiles/active_record-rails41.gemfile
 
     - rvm: jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - jruby
   - 1.9.3
   - 2.0.0
   - 2.1
@@ -8,6 +9,9 @@ rvm:
 
 gemfile:
   - Gemfile
+  - gemfiles/active_record-rails40.gemfile
+  - gemfiles/active_record-rails41.gemfile
+  - gemfiles/active_record-rails42.gemfile
 
 before_script:
   - mysql -e 'create database sorcery_test;'
@@ -20,45 +24,18 @@ matrix:
   allow_failures:
     - rvm: :jruby
 
-  include:
-    - rvm: jruby
-      gemfile: gemfiles/active_record-rails42.gemfile
-
-    - rvm: 2.1
-      gemfile: gemfiles/active_record-rails42.gemfile
-
-    - rvm: 2.2
-      gemfile: gemfiles/active_record-rails42.gemfile
-
-    - rvm: 2.3.0
-      gemfile: gemfiles/active_record-rails42.gemfile
-
+  exclude:
     - rvm: 1.9.3
-      gemfile: gemfiles/active_record-rails41.gemfile
+      gemfile: gemfiles/active_record-rails42.gemfile
 
     - rvm: 2.0.0
-      gemfile: gemfiles/active_record-rails41.gemfile
+      gemfile: gemfiles/active_record-rails42.gemfile
 
-    - rvm: 2.1
-      gemfile: gemfiles/active_record-rails41.gemfile
+    - rvm: jruby
+      gemfile: Gemfile
 
     - rvm: 2.2
-      gemfile: gemfiles/active_record-rails41.gemfile
+      gemfile: gemfiles/active_record-rails40.gemfile
 
     - rvm: 2.3.0
-      gemfile: gemfiles/active_record-rails41.gemfile
-
-    - rvm: jruby
-      gemfile: gemfiles/active_record-rails41.gemfile
-
-    - rvm: 1.9.3
-      gemfile: gemfiles/active_record-rails40.gemfile
-
-    - rvm: 2.0.0
-      gemfile: gemfiles/active_record-rails40.gemfile
-
-    - rvm: 2.1
-      gemfile: gemfiles/active_record-rails40.gemfile
-
-    - rvm: jruby
       gemfile: gemfiles/active_record-rails40.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ gemfile:
 before_script:
   - mysql -e 'create database sorcery_test;'
 
+before_install:
+  - rvm get stable --auto-dotfiles
+
 matrix:
   allow_failures:
     - rvm: :jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 
 before_install:
   - rvm get stable --auto-dotfiles
+  - gem update bundler
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Fixed 1.9.3, 2.1, 2.2 (outdated Bundler version 1.7.6 installed by rvm)
Fixed rvm unable to install binary 2.3 ruby build
Reworked build matrix to have a better idea which combinations are excluded (and reduce config size) (same combinations, [before](https://travis-ci.org/pirj/sorcery/builds/116077592) and [after](https://travis-ci.org/pirj/sorcery/builds/116080235))

PS Had to explicitly update bundler, since there was an inconsistency across gem/bundler versions being installed along with Ruby 1.9.3/2.1/2.2 between main and my fork repos builds.

<3

Fixes #752 