### PR TITLE
Don't bundle extra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ login_from(provider) # tries to login from the external provider's callback.
 create_from(provider) # create the user in the local app db.
 ```
 
+As of version 1.X the `oauth` and `oauth2` gems are not going to be bundled automatically.  
+You need to bundle the gems you need if you want to use the external module.  
+Here is a table of the external providers and their dependencies:  
+
+| Provider   | dependency |
+|------------|------------|
+| Facebook   | oauth2     |
+| Github     | oauth2     |
+| Google     | oauth2     |
+| Heroku     | oauth2     |
+| LiveId     | oauth2     |
+| SalesForce | oauth2     |
+| VK         | oauth2     |
+| Twitter    | oauth      |
+| Jira       | oauth      |
+| LinkedIn   | oauth      |
+| Xing       | oauth      |
+
 ### remember me
 ```ruby
 auto_login(user, should_remember=false)  # login without credentials, optional remember_me
@@ -308,6 +326,8 @@ Important notes while upgrading:
 
     *  `before_logout` does not take arguments anymore (`current_user` still returns user at this point)
     *  `after_logout` takes one argument (`user`) as `current_user` returns `nil` then
+    *  `oauth` and `oauth2` gems are not automatically bundled anymore, you need to add them to use the external module
+    *  `change_password!` now raises exception when it fails, to keep old behaviour change it to `change_password`
 
 *   If you are upgrading from <= **0.8.6** and you use Sorcery model methods in your app,
     you might need to change them from `user.method` to `user.sorcery_adapter.method` and from

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -69,6 +69,7 @@ module Sorcery
           submodules.each do |submodule|
             unless submodule == "http_basic_auth" || submodule == "session_timeout" || submodule == "core"
               migration_template "migration/#{submodule}.rb", "db/migrate/sorcery_#{submodule}.rb"
+              warn("Please add oauth/oauth2 dependencies to your Gemfile") if submodule == "external"
             end
           end
         end

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -69,7 +69,6 @@ module Sorcery
           submodules.each do |submodule|
             unless submodule == "http_basic_auth" || submodule == "session_timeout" || submodule == "core"
               migration_template "migration/#{submodule}.rb", "db/migrate/sorcery_#{submodule}.rb"
-              warn("Please add oauth/oauth2 dependencies to your Gemfile") if submodule == "external"
             end
           end
         end

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -7,6 +7,13 @@ module Sorcery
         def self.included(base)
           base.send(:include, InstanceMethods)
 
+          begin
+            require 'oauth'
+            require 'oauth2'
+          rescue LoadError
+            warn("\tPlease add oauth/oauth2 dependencies to your Gemfile")
+          end
+
           require 'sorcery/providers/base'
           require 'sorcery/providers/facebook'
           require 'sorcery/providers/twitter'

--- a/lib/sorcery/protocols/oauth.rb
+++ b/lib/sorcery/protocols/oauth.rb
@@ -1,5 +1,3 @@
-require 'oauth'
-
 module Sorcery
   module Protocols
     module Oauth

--- a/lib/sorcery/protocols/oauth2.rb
+++ b/lib/sorcery/protocols/oauth2.rb
@@ -1,5 +1,3 @@
-require 'oauth2'
-
 module Sorcery
   module Protocols
     module Oauth2

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency "oauth", "~> 0.4", ">= 0.4.4"
-  s.add_dependency "oauth2", ">= 0.8.0"
   s.add_dependency "bcrypt", "~> 3.1"
 
+  s.add_development_dependency "oauth", "~> 0.4", ">= 0.4.4"
+  s.add_development_dependency "oauth2", ">= 0.8.0"
   s.add_development_dependency "abstract", ">= 1.0.0"
   s.add_development_dependency "json", ">= 1.7.7"
   s.add_development_dependency "yard", "~> 0.6.0"


### PR DESCRIPTION
Move the requiring of the `oauth`/`oauth2` to the `external` submodule

Add a warning when the dependencies are not there in while generating the migration and the including the external module to notify the user about installing the gems

The warning only shows if the `oauth` _or_ `oauth2` are not bundled when initializing or requiring the `external` submodule

Know issues: if the user installed only `oauth2` (cause he doesn't need `oauth`) the warning still shows.
one solution to this problem is to move the requiring code inside each provider (but that will add a lot of duplicate code) and giving the user the ability to load specific providers (which is just a lot of work without any added benefit, since there is no problem in requiring a provider and never using it)

Solves: #773
