### PR TITLE
Fix deprecation warning of rails5 activerecord migration

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -63,12 +63,12 @@ module Sorcery
       def copy_migration_files
         # Copy core migration file in all cases except when you pass --only-submodules.
         return unless defined?(Sorcery::Generators::InstallGenerator::ActiveRecord)
-        migration_template "migration/core.rb", "db/migrate/sorcery_core.rb" unless only_submodules?
+        migration_template "migration/core.rb", "db/migrate/sorcery_core.rb", migration_class_name: migration_class_name unless only_submodules?
 
         if submodules
           submodules.each do |submodule|
             unless submodule == "http_basic_auth" || submodule == "session_timeout" || submodule == "core"
-              migration_template "migration/#{submodule}.rb", "db/migrate/sorcery_#{submodule}.rb"
+              migration_template "migration/#{submodule}.rb", "db/migrate/sorcery_#{submodule}.rb", migration_class_name: migration_class_name
             end
           end
         end
@@ -88,6 +88,14 @@ module Sorcery
       private
       def only_submodules?
         options[:migrations] || options[:only_submodules]
+      end
+
+      def migration_class_name
+        if Rails::VERSION::MAJOR >= 5
+          "ActiveRecord::Migration[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+        else
+          "ActiveRecord::Migration"
+        end
       end
 
     end

--- a/lib/generators/sorcery/templates/migration/activity_logging.rb
+++ b/lib/generators/sorcery/templates/migration/activity_logging.rb
@@ -1,4 +1,4 @@
-class SorceryActivityLogging < ActiveRecord::Migration
+class SorceryActivityLogging < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :last_login_at,     :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :last_logout_at,    :datetime, :default => nil

--- a/lib/generators/sorcery/templates/migration/brute_force_protection.rb
+++ b/lib/generators/sorcery/templates/migration/brute_force_protection.rb
@@ -1,4 +1,4 @@
-class SorceryBruteForceProtection < ActiveRecord::Migration
+class SorceryBruteForceProtection < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :failed_logins_count, :integer, :default => 0
     add_column :<%= model_class_name.tableize %>, :lock_expires_at, :datetime, :default => nil

--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -1,11 +1,11 @@
-class SorceryCore < ActiveRecord::Migration
+class SorceryCore < <%= migration_class_name %>
   def change
     create_table :<%= model_class_name.tableize %> do |t|
       t.string :email,            :null => false
       t.string :crypted_password
       t.string :salt
 
-      t.timestamps
+      t.timestamps                :null => false
     end
 
     add_index :<%= model_class_name.tableize %>, :email, unique: true

--- a/lib/generators/sorcery/templates/migration/external.rb
+++ b/lib/generators/sorcery/templates/migration/external.rb
@@ -1,10 +1,10 @@
-class SorceryExternal < ActiveRecord::Migration
+class SorceryExternal < <%= migration_class_name %>
   def change
     create_table :authentications do |t|
       t.integer :<%= model_class_name.tableize.singularize %>_id, :null => false
       t.string :provider, :uid, :null => false
 
-      t.timestamps
+      t.timestamps              :null => false
     end
 
     add_index :authentications, [:provider, :uid]

--- a/lib/generators/sorcery/templates/migration/remember_me.rb
+++ b/lib/generators/sorcery/templates/migration/remember_me.rb
@@ -1,4 +1,4 @@
-class SorceryRememberMe < ActiveRecord::Migration
+class SorceryRememberMe < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :remember_me_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :remember_me_token_expires_at, :datetime, :default => nil

--- a/lib/generators/sorcery/templates/migration/reset_password.rb
+++ b/lib/generators/sorcery/templates/migration/reset_password.rb
@@ -1,4 +1,4 @@
-class SorceryResetPassword < ActiveRecord::Migration
+class SorceryResetPassword < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :reset_password_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :reset_password_token_expires_at, :datetime, :default => nil

--- a/lib/generators/sorcery/templates/migration/user_activation.rb
+++ b/lib/generators/sorcery/templates/migration/user_activation.rb
@@ -1,4 +1,4 @@
-class SorceryUserActivation < ActiveRecord::Migration
+class SorceryUserActivation < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :activation_state, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :activation_token, :string, :default => nil


### PR DESCRIPTION
Change migration templates and migration generator for stop following deprecation wanings.

> DEPRECATION WARNING: Directly inheriting from ActiveRecord::Migration is deprecated.
> DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`.
