### PR TITLE
Deprecate Rails 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 matrix:
   allow_failures:
-    - rvm: :jruby
+    - rvm: jruby
 
   exclude:
     - rvm: 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * `current_users` method was removed
 * Added `logged_in?` `logged_out?` `online?` to activity_logging instance methods
 * PayPal provider added to external submodule
+* Deprecated Rails 3
+  * Deprecated using `callback_filter` in favor of `callback_action`
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * PayPal provider added to external submodule
 * Deprecated Rails 3
   * Deprecated using `callback_filter` in favor of `callback_action`
+  * Added null: false to migrations
 
 ## 0.9.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 3.2'
+gem 'rails', '~> 4.0'
 gem 'sqlite3'
 gem 'pry'
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ explaining and the rest are commented:
 
 ### core
 ```ruby
-require_login # this is a before filter
+require_login # this is a before action
 login(email, password, remember_me = false)
 auto_login(user)# login without credentials
 logout
@@ -72,7 +72,7 @@ User.authenticates_with_sorcery!
 
 ### http basic auth
 ```ruby
-require_login_from_http_basic # this is a before filter
+require_login_from_http_basic # this is a before action
 ```
 
 ### external
@@ -239,7 +239,7 @@ STI is supported via the `user.subclasses_inherit_config` setting in config/init
 
 **Basic HTTP Authentication** (see [lib/sorcery/controller/submodules/http_basic_auth.rb](https://github.com/NoamB/sorcery/blob/master/lib/sorcery/controller/submodules/http_basic_auth.rb)):
 
-*   A before filter for requesting authentication with HTTP Basic.
+*   A before action for requesting authentication with HTTP Basic.
 *   automatic login from HTTP Basic.
 *   automatic login is disabled if session key changed.
 

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -16,7 +16,7 @@ module Sorcery
     end
 
     module InstanceMethods
-      # To be used as before_filter.
+      # To be used as before_action.
       # Will trigger auto-login attempts via the call to logged_in?
       # If all attempts to auto-login fail, the failure callback will be called.
       def require_login

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -34,7 +34,11 @@ module Sorcery
           Config.after_login    << :register_login_time_to_db
           Config.after_login    << :register_last_ip_address
           Config.before_logout  << :register_logout_time_to_db
-          base.after_filter :register_last_activity_time_to_db
+          if Rails::VERSION::MAJOR >= 4
+            base.after_action :register_last_activity_time_to_db
+          else
+            base.after_filter :register_last_activity_time_to_db
+          end
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -34,11 +34,7 @@ module Sorcery
           Config.after_login    << :register_login_time_to_db
           Config.after_login    << :register_last_ip_address
           Config.before_logout  << :register_logout_time_to_db
-          if Rails::VERSION::MAJOR >= 4
-            base.after_action :register_last_activity_time_to_db
-          else
-            base.after_filter :register_last_activity_time_to_db
-          end
+          base.after_action :register_last_activity_time_to_db
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -2,7 +2,7 @@ module Sorcery
   module Controller
     module Submodules
       # This submodule integrates HTTP Basic authentication into sorcery.
-      # You are provided with a before filter, require_login_from_http_basic, 
+      # You are provided with a before action, require_login_from_http_basic,
       # which requests the browser for authentication.
       # Then the rest of the submodule takes care of logging the user in 
       # into the session, so that the next requests will keep him logged in.
@@ -26,14 +26,14 @@ module Sorcery
 
           protected
           
-          # to be used as a before_filter.
+          # to be used as a before_action.
           # The method sets a session when requesting the user's credentials.
           # This is a trick to overcome the way HTTP authentication works (explained below):
           #
           # Once the user fills the credentials once, the browser will always send it to the 
           # server when visiting the website, until the browser is closed.
           # This causes wierd behaviour if the user logs out. The session is reset, yet the 
-          # user is re-logged in by the before_filter calling 'login_from_basic_auth'.
+          # user is re-logged in by the before_action calling 'login_from_basic_auth'.
           # To overcome this, we set a session when requesting the password, which logout will
           # reset, and that's how we know if we need to request for HTTP auth again.
           def require_login_from_http_basic

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -21,7 +21,11 @@ module Sorcery
             merge_session_timeout_defaults!
           end
           Config.after_login << :register_login_time
-          base.prepend_before_filter :validate_session
+          if Rails::VERSION::MAJOR >= 4
+            base.prepend_before_action :validate_session
+          else
+            base.prepend_before_filter :validate_session
+          end
         end
 
         module InstanceMethods
@@ -34,7 +38,7 @@ module Sorcery
           end
 
           # Checks if session timeout was reached and expires the current session if so.
-          # To be used as a before_filter, before require_login
+          # To be used as a before_action, before require_login
           def validate_session
             session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
             if session_to_use && sorcery_session_expired?(session_to_use.to_time)

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -21,11 +21,7 @@ module Sorcery
             merge_session_timeout_defaults!
           end
           Config.after_login << :register_login_time
-          if Rails::VERSION::MAJOR >= 4
-            base.prepend_before_action :validate_session
-          else
-            base.prepend_before_filter :validate_session
-          end
+          base.prepend_before_action :validate_session
         end
 
         module InstanceMethods

--- a/lib/sorcery/test_helpers/internal/rails.rb
+++ b/lib/sorcery/test_helpers/internal/rails.rb
@@ -17,7 +17,7 @@ module Sorcery
           ::Sorcery::Controller::Config.init!
           ::Sorcery::Controller::Config.reset!
 
-          # remove all plugin before_filters so they won't fail other tests.
+          # remove all plugin before_actions so they won't fail other tests.
           # I don't like this way, but I didn't find another.
           # hopefully it won't break until Rails 4.
           chain = if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new("4.1.0")

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "timecop"
   s.add_development_dependency "simplecov", ">= 0.3.8"
-  s.add_development_dependency "rspec", "~> 3.0.0"
-  s.add_development_dependency "rspec-rails", "~> 3.0.0"
+  s.add_development_dependency "rspec", "~> 3.1.0"
+  s.add_development_dependency "rspec-rails", "~> 3.1.0"
   s.add_development_dependency "test-unit", "~> 3.1.0"
 end
 

--- a/spec/controllers/controller_http_basic_auth_spec.rb
+++ b/spec/controllers/controller_http_basic_auth_spec.rb
@@ -15,7 +15,7 @@ describe SorceryController do
       logout_user
     end
 
-    it "requests basic authentication when before_filter is used" do
+    it "requests basic authentication when before_action is used" do
       get :test_http_basic_auth
 
       expect(response.status).to eq 401

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -131,7 +131,7 @@ describe SorceryController do
     end
 
 
-    it "calls the configured 'not_authenticated_action' when authenticate before_filter fails" do
+    it "calls the configured 'not_authenticated_action' when authenticate before_action fails" do
       session[:user_id] = nil
       sorcery_controller_property_set(:not_authenticated_action, :test_not_authenticated_action)
       get :test_logout
@@ -139,14 +139,14 @@ describe SorceryController do
       expect(response.body).to eq "test_not_authenticated_action"
     end
 
-    it "require_login before_filter saves the url that the user originally wanted" do
+    it "require_login before_action saves the url that the user originally wanted" do
       get :some_action
 
       expect(session[:return_to_url]).to eq "http://test.host/some_action"
       expect(response).to redirect_to("http://test.host/")
     end
 
-    it "require_login before_filter does not save the url that the user originally wanted upon all non-get http methods" do
+    it "require_login before_action does not save the url that the user originally wanted upon all non-get http methods" do
       [:post, :put, :delete].each do |m|
         self.send(m, :some_action)
 

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -3,13 +3,8 @@ require 'oauth'
 class SorceryController < ActionController::Base
   protect_from_forgery
 
-  if Rails::VERSION::MAJOR >= 4
-    before_action :require_login_from_http_basic, only: [:test_http_basic_auth]
-    before_action :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
-  else
-    before_filter :require_login_from_http_basic, only: [:test_http_basic_auth]
-    before_filter :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
-  end
+  before_action :require_login_from_http_basic, only: [:test_http_basic_auth]
+  before_action :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
 
   def index
   end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -3,8 +3,13 @@ require 'oauth'
 class SorceryController < ActionController::Base
   protect_from_forgery
 
-  before_filter :require_login_from_http_basic, only: [:test_http_basic_auth]
-  before_filter :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
+  if Rails::VERSION::MAJOR >= 4
+    before_action :require_login_from_http_basic, only: [:test_http_basic_auth]
+    before_action :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
+  else
+    before_filter :require_login_from_http_basic, only: [:test_http_basic_auth]
+    before_filter :require_login, only: [:test_logout, :test_logout_with_force_forget_me, :test_should_be_logged_in, :some_action]
+  end
 
   def index
   end

--- a/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
+++ b/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
@@ -6,7 +6,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :crypted_password
       t.string :salt
 
-      t.timestamps
+      t.timestamps                :null => false
     end
   end
 

--- a/spec/rails_app/db/migrate/external/20101224223628_create_authentications_and_user_providers.rb
+++ b/spec/rails_app/db/migrate/external/20101224223628_create_authentications_and_user_providers.rb
@@ -4,14 +4,14 @@ class CreateAuthenticationsAndUserProviders < ActiveRecord::Migration
       t.integer :user_id, null: false
       t.string :provider, :uid, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     create_table :user_providers do |t|
       t.integer :user_id, null: false
       t.string :provider, :uid, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 


### PR DESCRIPTION
Fixes #756, Closes #763 (Merged and updated to not include filter), and Closes #784.

Thanks to @zernie for doing most of the legwork on this one. Just needed to update some gems and fix a timestamp deprecation.