### PR TITLE
Hotfix twitter login

### DIFF
--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -1,7 +1,7 @@
 class SorceryCore < <%= migration_class_name %>
   def change
     create_table :<%= model_class_name.tableize %> do |t|
-      t.string :email,            :null => false
+      t.string :email
       t.string :crypted_password
       t.string :salt
 

--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -2,6 +2,7 @@ class SorceryCore < <%= migration_class_name %>
   def change
     create_table :<%= model_class_name.tableize %> do |t|
       t.string :email
+      t.string :username
       t.string :crypted_password
       t.string :salt
 


### PR DESCRIPTION
# About the bug
I found a bug with Twitter login with external module reported at the [issue #800](https://github.com/NoamB/sorcery/issues/800)

# How to fix
I tried to fix it by myself, then I add username property to and remove not null constraint of email from users in `lib/generators/sorcery/templates/migration/core.rb`.

Username is needed when you login with Twitter, but email isn't needed.

Without username property, it raises error(mentioned in [issue #800](https://github.com/NoamB/sorcery/issues/800)).

Thinking about email, not null constraint in a database layer raises an error
at `user.sorcery_adapter.save(:validate => false)` in `#create_from_provider` in  `lib/sorcery/model/submodules/external.rb`.  
The error is:
```
Mysql2::Error: Field 'email' doesn't have a default value: INSERT INTO `users` (`username`, `created_at`, `updated_at`) VALUES ('blablabla', '2016-09-22 15:56:22', '2016-09-22 15:56:22')
```

Using #save with validate option, expected that a validation of email is ignored. The validation should be imposed only in model.

I wonder why tests don't fail, looking into specs.
In `spec/rails_app/db/migrate/core/20101224223620_create_users.rb`, different from the migration template mentioned above, defined are columns username and email without not null constraint.

I think users defined in tests is expected, and I fix in this way.

# How to test
I run all tests by `bundle exec rpsec`.  
I also confirmed expected migration template as follows:
```ruby
class SorceryCore < ActiveRecord::Migration
  def change
    create_table :users do |t|
      t.string :email
      t.string :username
      t.string :crypted_password
      t.string :salt

      t.timestamps
    end

    add_index :users, :email, unique: true
  end
end
```

I'm looking forward to a comment. Thank you for reading.